### PR TITLE
Add custom favicon with recipe book icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>recipe-management-frontend</title>
+    <title>Recipe Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#2563eb;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#9333ea;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Book/Recipe icon -->
+  <rect x="20" y="15" width="60" height="70" rx="4" fill="url(#grad)"/>
+  
+  <!-- Pages effect -->
+  <rect x="23" y="18" width="54" height="64" rx="2" fill="white" opacity="0.95"/>
+  
+  <!-- Recipe lines -->
+  <line x1="30" y1="30" x2="70" y2="30" stroke="url(#grad)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="30" y1="40" x2="65" y2="40" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="48" x2="68" y2="48" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="30" y1="56" x2="62" y2="56" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"/>
+  
+  <!-- Small chef hat icon -->
+  <circle cx="50" cy="68" r="8" fill="url(#grad)" opacity="0.2"/>
+  <path d="M 45 70 Q 50 65 55 70 L 54 74 L 46 74 Z" fill="url(#grad)"/>
+</svg>


### PR DESCRIPTION
## Summary
Replaces the default Vite favicon with a custom-designed SVG favicon that matches the app's branding.

## Changes
- ✨ Created custom SVG favicon with recipe book design
- 🎨 Uses the app's signature blue-to-purple gradient
- 📝 Features a recipe book icon with lines and a chef hat accent
- 🏷️ Updated page title from 'recipe-management-frontend' to 'Recipe Manager'

## Design
The favicon shows:
- A recipe book with gradient cover
- White pages with recipe lines
- Small chef hat icon for visual interest
- Matches the blue-purple gradient used throughout the app

## Files Changed
- `public/favicon.svg` - New custom favicon
- `index.html` - Updated favicon reference and page title

## Benefits
- Better brand identity in browser tabs
- Professional appearance
- Matches the app's gradient theme
- Easy to spot among multiple tabs