### PR TITLE
Fix Playwright installation to avoid user input

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -27,6 +27,7 @@ steps:
     if: "build.branch == 'main'"
     command:
       - "npm ci"
+      - "npm install playwright@1.56.1 --yes"
       - "npx playwright install --with-deps"
       - "npx playwright test"
     plugins:


### PR DESCRIPTION
This PR updates the Buildkite pipeline to ensure Playwright is installed without requiring user input by adding the --yes flag.