### PR TITLE
Add test mode for E2E tests (no authentication required)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+test-results/
+playwright-report/
+playwright/.auth/
+
 # Environment variables
 .env
 .env.local

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
+    command: 'VITE_TEST_MODE=true npm run dev',
     url: 'http://localhost:5173',
     reuseExistingServer: !process.env.CI,
   },

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -8,6 +8,13 @@ interface ProtectedRouteProps {
 
 export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth()
+  
+  // Bypass authentication in test mode
+  const isTestMode = import.meta.env.VITE_TEST_MODE === 'true'
+  
+  if (isTestMode) {
+    return <>{children}</>
+  }
 
   if (isLoading) {
     return (

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,72 @@
+# E2E Testing with Playwright
+
+## Setup
+
+### Prerequisites
+1. Install dependencies: `npm install`
+2. Install Playwright browsers: `npx playwright install --with-deps`
+
+### Test Mode
+
+The E2E tests run in **test mode**, which bypasses authentication requirements. This is controlled by the `VITE_TEST_MODE` environment variable, which is automatically set when running Playwright tests.
+
+**No authentication setup is required!** The tests will run against an unauthenticated version of the app.
+
+## Running Tests
+
+### Run all tests
+```bash
+npm run test:e2e
+```
+
+### Run tests in UI mode (interactive)
+```bash
+npm run test:e2e:ui
+```
+
+### Run tests in headed mode (see browser)
+```bash
+npx playwright test --headed
+```
+
+### Run specific test file
+```bash
+npx playwright test tests/create-recipe-wizard.spec.ts
+```
+
+### Debug tests
+```bash
+npx playwright test --debug
+```
+
+## Viewing Test Reports
+
+After running tests, view the HTML report:
+```bash
+npx playwright show-report
+```
+
+## CI/CD Integration
+
+The Buildkite pipeline runs E2E tests only on the `main` branch. The test mode is automatically enabled via the webServer command in `playwright.config.ts`.
+
+## How Test Mode Works
+
+When `VITE_TEST_MODE=true` is set:
+- The `ProtectedRoute` component bypasses authentication checks
+- Protected routes are accessible without login
+- No Firebase authentication is required
+
+This allows E2E tests to focus on testing functionality rather than authentication flows.
+
+## Troubleshooting
+
+### Tests failing with "element not found"
+- Make sure your dev server is running
+- Verify the UI elements match the selectors in the test
+- Check the Playwright trace viewer for more details
+
+### Timeout errors
+- Increase timeout in `playwright.config.ts` if needed
+- Check network requests in Playwright trace viewer
+- Ensure the dev server is responding quickly

--- a/tests/test-mode.spec.ts
+++ b/tests/test-mode.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Test Mode Verification', () => {
+  test('should bypass authentication and access dashboard', async ({ page }) => {
+    // Go directly to dashboard (protected route)
+    await page.goto('/dashboard')
+    
+    // Should not redirect to login
+    await expect(page).not.toHaveURL(/\/login/)
+    
+    // Should see dashboard content
+    await expect(page.getByText(/dashboard|recipes/i)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('should access create recipe page without authentication', async ({ page }) => {
+    // Go directly to create recipe page (protected route)
+    await page.goto('/dashboard/create-recipe')
+    
+    // Should not redirect to login
+    await expect(page).not.toHaveURL(/\/login/)
+    
+    // Should see the create recipe form
+    await expect(page.locator('form')).toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Problem
E2E tests were failing because they required authentication setup, making them complex and brittle. The previous approach required maintaining test credentials and auth state.

## Solution
Implemented a test mode similar to the recipe-generator-stack-a project that bypasses authentication for E2E testing:

### Changes:
- ✅ Added `VITE_TEST_MODE` environment variable support
- ✅ Updated `ProtectedRoute` to bypass auth when test mode is enabled
- ✅ Simplified Playwright config (no auth setup needed)
- ✅ Removed complex `auth.setup.ts` file
- ✅ Added `test-mode.spec.ts` to verify bypass works
- ✅ Updated test README with simpler setup instructions
- ✅ Added Playwright directories to .gitignore

### How it Works:
When `VITE_TEST_MODE=true` is set (automatically via Playwright config):
- The `ProtectedRoute` component bypasses authentication checks
- Protected routes are accessible without login
- No Firebase authentication is required
- Tests can focus on functionality rather than auth flows

### Testing:
```bash
npm run test:e2e
```

The test-mode verification tests pass, confirming authentication bypass works correctly.

## Next Steps:
- Update the existing `create-recipe-wizard.spec.ts` tests to match actual UI
- The test mode is ready for Buildkite integration