### PR TITLE
Remove timeout for E2E tests in pipeline

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -25,7 +25,6 @@ steps:
 
   - label: ":playwright: E2E Tests"
     if: "build.branch == 'main'"
-    timeout_in_minutes: 10
     command:
       - "npm ci"
       - "'y' | npx playwright install --with-deps"


### PR DESCRIPTION
Removed timeout setting for E2E tests in pipeline.
This pull request makes a minor update to the Buildkite pipeline configuration by removing the explicit timeout setting for the Playwright E2E tests step. This means the step will now use the default timeout.

- Build pipeline configuration:
  * Removed the `timeout_in_minutes: 10` setting from the Playwright E2E test step in `buildkite/pipeline.yml`, so the default timeout will apply.