### PR TITLE
Fix: Add environment variables to deployment build step

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,6 +29,15 @@ jobs:
 
       - name: Build application
         run: npm run build
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_STORAGE_API_URL: ${{ secrets.VITE_STORAGE_API_URL }}
 
       - name: Deploy to Firebase
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/GITHUB_SECRETS_SETUP.md
+++ b/GITHUB_SECRETS_SETUP.md
@@ -1,0 +1,86 @@
+# GitHub Secrets Setup for Deployment
+
+## Problem
+The deployed site shows `Firebase: Error (auth/invalid-api-key)` because environment variables aren't available during the build process.
+
+## Solution
+Add Firebase configuration as GitHub repository secrets so they're available when GitHub Actions builds the app.
+
+## Steps to Add Secrets
+
+1. **Go to your GitHub repository settings:**
+   ```
+   https://github.com/theandiman/recipe-management-frontend/settings/secrets/actions
+   ```
+
+2. **Click "New repository secret"** and add each of these secrets:
+
+### Required Secrets
+
+Get the values from your `.env.local` file and add them as secrets:
+
+| Secret Name | Description | Where to Find |
+|-------------|-------------|---------------|
+| `VITE_FIREBASE_API_KEY` | Firebase API key | `.env.local` or Firebase Console → Project Settings |
+| `VITE_FIREBASE_AUTH_DOMAIN` | Firebase auth domain | `.env.local` (usually `{project-id}.firebaseapp.com`) |
+| `VITE_FIREBASE_PROJECT_ID` | Firebase project ID | `.env.local` or Firebase Console |
+| `VITE_FIREBASE_STORAGE_BUCKET` | Firebase storage bucket | `.env.local` (usually `{project-id}.appspot.com`) |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | Firebase messaging sender ID | `.env.local` or Firebase Console |
+| `VITE_FIREBASE_APP_ID` | Firebase app ID | `.env.local` or Firebase Console |
+| `VITE_API_URL` | Backend AI service URL | `.env.local` (Cloud Run URL) |
+| `VITE_STORAGE_API_URL` | Storage service URL | `.env.local` (Cloud Run URL) |
+
+### Already Configured
+
+These secrets should already exist (used by deployment workflow):
+- ✅ `FIREBASE_SERVICE_ACCOUNT_DEV`
+- ✅ `FIREBASE_PROJECT_ID_DEV`
+- ✅ `GITHUB_TOKEN` (automatically provided by GitHub)
+
+## Quick Copy from .env.local
+
+To see your current values:
+```bash
+cat .env.local
+```
+
+## Verification
+
+After adding the secrets:
+
+1. **Trigger a new deployment:**
+   ```bash
+   git commit --allow-empty -m "Trigger deployment with environment variables"
+   git push origin main
+   ```
+
+2. **Check the build logs** in GitHub Actions to verify environment variables are being used
+
+3. **Visit your deployed site** - Firebase errors should be gone!
+
+## Security Note
+
+⚠️ **Never commit `.env.local` or `.env` files to Git**
+
+These files contain sensitive credentials. They're already in `.gitignore` to prevent accidental commits.
+
+## How It Works
+
+1. **Local development:** Uses `.env.local` (gitignored)
+2. **GitHub Actions build:** Uses GitHub secrets 
+3. **Vite build process:** Replaces `import.meta.env.VITE_*` with actual values at build time
+4. **Deployed site:** Has environment variables baked into the compiled JavaScript
+
+## Troubleshooting
+
+**If you still see Firebase errors after adding secrets:**
+
+1. Check that secret names match exactly (case-sensitive)
+2. Verify secrets have values (not empty)
+3. Re-run the deployment workflow
+4. Check GitHub Actions logs for any error messages
+
+**To get Firebase config values:**
+
+Visit Firebase Console → Project Settings → Your apps → Web app → Config:
+https://console.firebase.google.com/project/{your-project-id}/settings/general


### PR DESCRIPTION
## Problem

The deployed site was throwing a Firebase authentication error:
```
FirebaseError: Firebase: Error (auth/invalid-api-key)
```

## Root Cause

Vite replaces `import.meta.env.VITE_*` variables at **build time**, not runtime. The deployment workflow's build step was running without environment variables, causing all Firebase config values to be compiled as `undefined`.

## Solution

Added environment variables to the build step in `.github/workflows/deploy-dev.yml`:
- `VITE_FIREBASE_API_KEY`
- `VITE_FIREBASE_AUTH_DOMAIN`
- `VITE_FIREBASE_PROJECT_ID`
- `VITE_FIREBASE_STORAGE_BUCKET`
- `VITE_FIREBASE_MESSAGING_SENDER_ID`
- `VITE_FIREBASE_APP_ID`
- `VITE_API_URL`
- `VITE_STORAGE_API_URL`

These are injected from GitHub repository secrets during the build process, ensuring Vite compiles the correct values into the static bundle.

## Security Notes

✅ No `.env` files are created or committed
✅ Secrets stored securely in GitHub repository secrets
✅ Environment variables injected only during build process
✅ Values compiled into JavaScript bundle for static site deployment

## Changes

- Modified `.github/workflows/deploy-dev.yml` to add `env:` block to build step
- Added `GITHUB_SECRETS_SETUP.md` with setup instructions (GitHub secrets already configured)

## Testing

GitHub secrets have been configured. Once merged, the next deployment will build with the correct Firebase configuration.