### PR TITLE
Add environment details for Firebase Dev deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,7 +219,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [lint, type-check, unit-tests, e2e-tests, build]
-    environment: dev
+    environment: 
+      name: dev
+      url: 'https://recipe-mgmt-dev.web.app/'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the deployment job configuration in the GitHub Actions workflow to provide a more detailed environment specification. Instead of just specifying the environment name, it now also includes the deployment URL, which can help with tracking and accessing deployed environments.

Deployment workflow configuration:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L222-R224): Changed the `environment` field in the deployment job to use an object with both `name` (`dev`) and `url` (`https://recipe-mgmt-dev.web.app/`), instead of just the environment name.