### PR TITLE
fix: Merge imageUrl from Redux state before saving AI recipe

### DIFF
--- a/src/features/recipes/AIGenerator.tsx
+++ b/src/features/recipes/AIGenerator.tsx
@@ -104,7 +104,13 @@ export const AIGenerator: React.FC = () => {
     setSaveSuccess(false)
 
     try {
-      await saveRecipe(parsedRecipe)
+      // Merge the imageUrl from Redux state into the recipe before saving
+      const recipeToSave = {
+        ...parsedRecipe,
+        imageUrl: imageUrl || parsedRecipe.imageUrl
+      }
+      
+      await saveRecipe(recipeToSave)
       setSaveSuccess(true)
       // Clear success message after 3 seconds
       setTimeout(() => setSaveSuccess(false), 3000)


### PR DESCRIPTION
## Problem
When saving an AI-generated recipe with an image, the save fails with a CORS preflight error:
```
Access to XMLHttpRequest at 'https://firebasestorage.googleapis.com/...' has been blocked by CORS policy
```

The root cause: The `imageUrl` from Redux state (populated by `generateImage`) was never merged into the recipe before saving. The `parsedRecipe` object only contained the initial recipe JSON without the generated image URL.

## Solution
Modified `handleSaveRecipe` in `AIGenerator.tsx` to merge the `imageUrl` from Redux state into the recipe before calling `saveRecipe`:

```typescript
const recipeToSave = {
  ...parsedRecipe,
  imageUrl: imageUrl || parsedRecipe.imageUrl
}
await saveRecipe(recipeToSave)
```

## Testing
1. ✅ Generate an AI recipe with image
2. ✅ Click Save Recipe button
3. ✅ Verify image is included in the save request
4. ⏳ After infrastructure PR merges (adds Cloud Run URLs to Storage CORS), verify complete upload flow

## Related
- Depends on: theandiman/recipe-management-infrastructure#36 (CORS config)
- Manual recipe saves already work (they include imageUrl from form state)