### PR TITLE
feat: add dashboard navigation link to sidebar

### DIFF
--- a/src/components/Layout/DashboardLayout.tsx
+++ b/src/components/Layout/DashboardLayout.tsx
@@ -34,6 +34,16 @@ export const DashboardLayout: React.FC = () => {
 
   const navItems = [
     {
+      name: 'Dashboard',
+      path: '/dashboard',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5a2 2 0 012-2h4a2 2 0 012 2v2H8V5z" />
+        </svg>
+      ),
+    },
+    {
       name: 'Browse Recipes',
       path: '/dashboard/recipes',
       icon: (


### PR DESCRIPTION
## What This PR Does
Adds a 'Dashboard' navigation item to the sidebar for easy access to the main overview page from any sub-page.

## Problem Solved
Users could navigate to sub-pages (Create Recipe, Browse Recipes, AI Generator) but had no way to return to the main dashboard overview through the sidebar navigation.

## Changes Made
- Added 'Dashboard' navigation item to the  array in 
- Includes home icon for clear visual identification
- Proper active state styling when on dashboard page
- Maintains consistent animation and design with existing navigation items

## Navigation Structure
The sidebar now provides complete navigation access:
- 🏠 **Dashboard** - Main overview with stats, quick actions, and recent recipes
- 📚 **Browse Recipes** - Full recipe library with pagination  
- ➕ **Create Recipe** - Manual recipe creation wizard
- ⚡ **AI Generator** - AI-powered recipe generation

## Testing
- ✅ Build completes successfully with no errors
- ✅ Navigation works correctly between all pages
- ✅ Active state styling works properly
- ✅ Responsive design maintained on mobile

## Related
- Closes navigation gap identified after PR #78 merge
- Improves user experience by providing complete navigation accessibility