### PR TITLE
fix: apply npm optional dependencies workaround to deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,9 @@ jobs:
           scope: '@theandiman'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
 


### PR DESCRIPTION
## Problem

The deploy job is failing on main with:
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try npm i again after removing both package-lock.json and node_modules directory.
```

## Root Cause

The deploy job was still using `npm ci` which triggers the npm optional dependencies bug with rollup. This same bug was fixed for other jobs in PR #104, but the deploy job was missed.

## Solution

Apply the same workaround that was added to unit-tests, build, and e2e-tests jobs in PR #104:

```yaml
- name: Install dependencies
  run: |
    rm -rf node_modules package-lock.json
    npm install
```

Instead of:
```yaml
- name: Install dependencies
  run: npm ci
```

## Testing

This fix matches the working pattern in other jobs. After merging, the deployment should succeed.

## Related

- PR #104 - Initial fix for npm optional dependencies bug
- PR #109 - Recent merge that revealed this deployment issue