### PR TITLE
fix: Override ZAP action artifact_name to use hyphens instead of underscores

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,6 +409,7 @@ jobs:
           cmd_options: '-a'
           allow_issue_writing: false
           fail_action: false
+          artifact_name: 'zap-scan'
 
       - name: Upload ZAP Scan Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

Post-deployment tests are failing with:
```
Error: Create Artifact Container failed: The artifact name zap_scan is not valid.
```

This prevents the OWASP ZAP security scan from completing and uploading its reports.

## Root Cause

The `zaproxy/action-baseline@v0.12.0` action has a **default artifact_name of `zap_scan`** (with underscore).

GitHub Actions **artifact names cannot contain underscores** - they must use hyphens, alphanumerics, or periods only.

## Solution

Override the default `artifact_name` parameter in the ZAP action configuration:

```yaml
- name: OWASP ZAP Baseline Scan
  uses: zaproxy/action-baseline@v0.12.0
  with:
    target: 'https://recipe-mgmt-dev.web.app/'
    rules_file_name: '.zap/rules.tsv'
    cmd_options: '-a'
    allow_issue_writing: false
    fail_action: false
    artifact_name: 'zap-scan'  # ← Override default 'zap_scan'
```

## Impact

After this fix:
- ✅ ZAP scan will complete successfully
- ✅ Security scan reports will be uploaded as `zap-scan` artifact
- ✅ Post-deployment tests will pass
- ✅ 30-day retention of ZAP scan reports

## Testing

The ZAP scan will run when this PR is merged to main and triggers a deployment.

## Related

- PR #111 - Original OWASP ZAP integration
- [GitHub Actions Artifact Naming](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#naming-artifacts)