### PR TITLE
fix: Run OWASP ZAP scan directly with Docker to avoid action permission issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -402,21 +402,37 @@ jobs:
           fi
 
       - name: OWASP ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.12.0
-        with:
-          target: 'https://recipe-mgmt-dev.web.app/'
-          rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-a'
-          allow_issue_writing: false
-          fail_action: false
-          artifact_name: 'zap-scan'
+        run: |
+          echo "Running OWASP ZAP baseline scan..."
+          docker pull ghcr.io/zaproxy/zaproxy:stable
+          
+          # Create report files with proper permissions
+          touch zap_report.html zap_report.json zap_report.md
+          chmod 666 zap_report.html zap_report.json zap_report.md
+          
+          # Run ZAP baseline scan
+          docker run -v ${{ github.workspace }}:/zap/wrk/:rw \
+            --network=host \
+            -t ghcr.io/zaproxy/zaproxy:stable \
+            zap-baseline.py \
+            -t https://recipe-mgmt-dev.web.app/ \
+            -r zap_report.html \
+            -J zap_report.json \
+            -w zap_report.md \
+            -a \
+            -c .zap/rules.tsv || true
+          
+          echo "✅ ZAP scan completed"
 
       - name: Upload ZAP Scan Report
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: zap-scan-report
-          path: report_html.html
+          path: |
+            zap_report.html
+            zap_report.json
+            zap_report.md
           retention-days: 30
 
       - name: Post-deployment summary


### PR DESCRIPTION
## Problem

Even after fixing the artifact name in PR #113, the ZAP scan still fails with:
```
Unable to copy yaml file to /zap/wrk/zap.yaml [Errno 13] Permission denied
Error: Create Artifact Container failed: The artifact name zap-scan is not valid
```

The `zaproxy/action-baseline` action has persistent issues with Docker volume mount permissions and artifact handling.

## Root Cause

The action's complex internal implementation causes:
1. **Permission issues** with Docker volume mounts
2. **Inconsistent artifact handling** even with valid names  
3. **Limited transparency** making debugging difficult

## Solution

**Run ZAP scan directly with Docker** using the official ZAP image:

```yaml
- name: OWASP ZAP Baseline Scan
  run: |
    docker pull ghcr.io/zaproxy/zaproxy:stable
    
    # Create report files with proper permissions
    touch zap_report.html zap_report.json zap_report.md
    chmod 666 zap_report.html zap_report.json zap_report.md
    
    # Run ZAP baseline scan
    docker run -v \${{ github.workspace }}:/zap/wrk/:rw \\
      --network=host \\
      -t ghcr.io/zaproxy/zaproxy:stable \\
      zap-baseline.py \\
      -t https://recipe-mgmt-dev.web.app/ \\
      -r zap_report.html \\
      -J zap_report.json \\
      -w zap_report.md \\
      -a \\
      -c .zap/rules.tsv || true
```

## Benefits

✅ **Eliminates permission issues** - Proper file permissions set before Docker run  
✅ **Full control** - Direct Docker commands, no action wrapper  
✅ **Transparent execution** - Easy to see exactly what's running  
✅ **Same ZAP capability** - Uses official `ghcr.io/zaproxy/zaproxy:stable` image  
✅ **Multiple report formats** - HTML, JSON, and Markdown  
✅ **Non-blocking** - `|| true` prevents deployment failure on scan issues  
✅ **Clean artifacts** - Manual upload with valid name  

## Reports Generated

Three report formats uploaded as `zap-scan-report` artifact:
- **zap_report.html** - Human-readable HTML report with full scan details
- **zap_report.json** - Machine-readable JSON for automation/integration
- **zap_report.md** - Markdown summary for quick review

## Testing

The ZAP scan will run when this PR is merged to main and triggers a deployment. Check the "Post-Deployment Tests" job to see:
1. ZAP scan execution
2. Security findings
3. Artifact upload success

## Related

- PR #111 - Original OWASP ZAP integration
- PR #113 - First attempt to fix artifact name (still had permission issues)
- [ZAP Docker Baseline Scan Documentation](https://www.zaproxy.org/docs/docker/baseline-scan/)