### PR TITLE
feat: Add make install command with GitHub Packages authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 	@echo "Ensuring GitHub token has read:packages scope..."
 	gh auth refresh -s read:packages
 	@echo "Setting GITHUB_TOKEN and running npm install..."
-	@export GITHUB_TOKEN=$$(gh auth token) && npm install
+	@GITHUB_TOKEN=$$(gh auth token) npm install
 
 # Default dev target: ensure env exists then run dev server
 dev: bootstrap-env


### PR DESCRIPTION
## Summary
Add new `make install` target that automatically handles GitHub Packages authentication for installing npm dependencies.

## Changes
- Added `make install` command to Makefile
- Automatically checks for GitHub CLI (gh) installation
- Verifies GitHub authentication status
- Refreshes token with `read:packages` scope if needed
- Exports `GITHUB_TOKEN` and runs `npm install`

## Benefits
- Simplifies developer onboarding
- Eliminates manual token configuration
- Handles authentication errors gracefully
- Provides clear error messages for missing dependencies

## Usage
```bash
make install
```

## Testing
✅ Tested locally with successful npm install
✅ Handles unauthenticated state (prompts login)
✅ Refreshes token with correct scopes

Resolves authentication issues with `@theandiman/recipe-management-shared` package.