### PR TITLE
fix: generate coverage in SonarCloud job instead of downloading artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,11 +210,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
 
-      - name: Download coverage artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: ./coverage
+      - name: Run tests with coverage
+        run: npm test -- --run --coverage
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v2


### PR DESCRIPTION
## Problem
The SonarCloud job on main is failing because it tries to download a coverage artifact that doesn't exist:
```
Unable to download artifact(s): Artifact not found for name: coverage-report
```

The unit-tests job doesn't upload a coverage artifact - it only sends coverage to Codecov.

## Solution
Have the SonarCloud job run tests itself to generate coverage data instead of trying to download a non-existent artifact.

## Changes
- Removed `Download coverage artifact` step
- Added `Run tests with coverage` step before SonarCloud scan

This matches the approach we successfully used in the storage-service.