### PR TITLE
fix: upgrade SonarCloud action to v3.1.0 to resolve scanner NPE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,7 @@ jobs:
         run: npm test -- --run --coverage
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v2
+        uses: SonarSource/sonarcloud-github-action@v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem
SonarCloud scanner was failing on main branch with NullPointerException:
```
java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "map" is null
    at org.sonar.scanner.featureflag.FeatureFlagSettingsProvider.provide()
```

This is a known issue in v2 of the SonarCloud GitHub Action.

## Solution
Upgraded `SonarSource/sonarcloud-github-action` from v2 to v3.1.0

## Impact
- Resolves scanner initialization failure
- Unblocks SonarCloud quality gate checks
- Will allow verification of 3.3% overall duplication achievement

## Related
- Failed run: https://github.com/theandiman/recipe-management-frontend/actions/runs/20193416270/job/57974008526
- Latest stable version available: v5.0.0 (chose v3.1.0 for conservative upgrade)