### PR TITLE
fix(ci): use GITHUB_TOKEN for GitHub Packages installs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 # Required permissions for the workflow
 permissions:
   contents: read
+  packages: read
   pull-requests: write
   issues: write
   checks: write
@@ -39,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESLint
         run: npm run lint
@@ -63,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TypeScript type check
         run: npx tsc --noEmit
@@ -89,7 +90,7 @@ jobs:
           rm -rf node_modules package-lock.json
           npm install
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run unit tests
         run: npm test -- --run --coverage
@@ -124,7 +125,7 @@ jobs:
           rm -rf node_modules package-lock.json
           npm install
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -171,7 +172,7 @@ jobs:
           rm -rf node_modules package-lock.json
           npm install
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for production
         run: npm run build
@@ -208,7 +209,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with coverage
         run: npm test -- --run --coverage
@@ -251,7 +252,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run npm audit
         run: npm audit --audit-level=moderate
@@ -304,7 +305,7 @@ jobs:
           rm -rf node_modules package-lock.json
           npm install
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build for production with environment secrets
         run: npm run build


### PR DESCRIPTION
## Summary
Switches CI package authentication from the custom `GH_REGISTRY_READER` secret to built-in `GITHUB_TOKEN`.

## Changes
- Add workflow permission: `packages: read`
- Replace all `NODE_AUTH_TOKEN: ${{ secrets.GH_REGISTRY_READER }}` with `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in `.github/workflows/main.yml`

## Why
PR checks were failing with `npm.pkg.github.com` 401 unauthorized errors due to expired/invalid custom PAT. Using `GITHUB_TOKEN` removes that rotation burden for CI package reads.

## Expected outcome
- `npm ci` / `npm install` steps in lint, type-check, unit-tests, e2e-tests, build, sonarcloud, security-scan, and deploy jobs can authenticate to GitHub Packages without `GH_REGISTRY_READER`.
