### PR TITLE
fix(ci): prevent Renovate auto-approve workflow failures

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -86,6 +86,7 @@ jobs:
       - name: Auto-approve PR
         if: steps.check-type.outputs.should-automerge == 'true'
         uses: hmarr/auto-approve-action@v4
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Fixes failing `Renovate Automerge` checks caused by GitHub rejecting bot approvals with:
`GitHub Actions is not permitted to approve pull requests`.

## Root cause
`hmarr/auto-approve-action` can fail when repository settings disallow GitHub Actions approvals on some PR contexts.

## Change
- In `.github/workflows/renovate-automerge.yml`, make `Auto-approve PR` step non-blocking with:
  - `continue-on-error: true`

## Result
- Renovate automerge workflow no longer fails purely due to approval permission restrictions.
- The follow-up automerge enable logic still runs and logs status.
