### PR TITLE
fix(frontend): restore recipe loading from management service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,7 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: "123456789"
           VITE_FIREBASE_APP_ID: test-app-id
           VITE_API_URL: http://localhost:8080
+          VITE_MANAGEMENT_API_URL: http://localhost:8081
           VITE_STORAGE_API_URL: http://localhost:8081
 
       - name: Upload Playwright report
@@ -195,6 +196,7 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: '123456789'
           VITE_FIREBASE_APP_ID: 'build-test-app'
           VITE_API_URL: 'http://localhost:8080'
+          VITE_MANAGEMENT_API_URL: 'http://localhost:8081'
           VITE_STORAGE_API_URL: 'http://localhost:8081'
 
   # Code Quality Analysis
@@ -333,6 +335,7 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_MANAGEMENT_API_URL: ${{ secrets.VITE_MANAGEMENT_API_URL || secrets.VITE_STORAGE_API_URL }}
           VITE_STORAGE_API_URL: ${{ secrets.VITE_STORAGE_API_URL }}
 
       - name: Deploy to Firebase

--- a/src/services/recipeStorageApi.test.ts
+++ b/src/services/recipeStorageApi.test.ts
@@ -80,7 +80,7 @@ describe('recipeStorageApi', () => {
       expect(postWithAuth).toHaveBeenCalledWith(
         expect.stringContaining('/api/recipes'),
         expect.objectContaining({
-          recipeName: 'Test Recipe',
+          title: 'Test Recipe',
           ingredients: mockRecipe.ingredients,
           instructions: mockRecipe.instructions
         })
@@ -103,8 +103,8 @@ describe('recipeStorageApi', () => {
       expect(postWithAuth).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          prepTimeMinutes: 30,
-          cookTimeMinutes: 60
+          prepTime: 30,
+          cookTime: 60
         })
       )
     })
@@ -131,9 +131,9 @@ describe('recipeStorageApi', () => {
         expect.objectContaining({
           tips: {
             substitutions: ['sub 1', 'sub 2'],
-            makeAhead: 'Can be made ahead',
-            storage: 'Store in fridge',
-            reheating: 'Reheat in oven',
+            makeAhead: ['Can be made ahead'],
+            storage: ['Store in fridge'],
+            reheating: ['Reheat in oven'],
             variations: ['var 1']
           }
         })
@@ -217,6 +217,49 @@ describe('recipeStorageApi', () => {
       )
       expect(result).toEqual(mockRecipes)
     })
+
+    it('should map management-service recipe fields to the shared frontend shape', async () => {
+      const axios = (await import('axios')).default
+
+      vi.mocked(axios.get).mockResolvedValue(createAxiosResponse([
+        {
+          id: 'backend-1',
+          userId: 'test-user-id',
+          title: 'Mapped Recipe',
+          description: 'Mapped from backend',
+          ingredients: ['ingredient 1'],
+          instructions: ['step 1'],
+          prepTime: 15,
+          cookTime: 30,
+          servings: 2,
+          nutrition: { calories: 450, protein: 20 },
+          tips: {
+            makeAhead: ['Make the sauce in advance'],
+            storage: ['Keep refrigerated for up to 3 days'],
+            substitutions: ['Use tofu'],
+            variations: ['Add chili flakes']
+          },
+          source: 'manual',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z'
+        }
+      ]))
+
+      const [recipe] = await getRecipes()
+
+      expect(recipe.recipeName).toBe('Mapped Recipe')
+      expect(recipe.prepTimeMinutes).toBe(15)
+      expect(recipe.cookTimeMinutes).toBe(30)
+      expect(recipe.nutritionalInfo).toEqual({
+        perServing: { calories: 450, protein: 20 }
+      })
+      expect(recipe.tips).toEqual(expect.objectContaining({
+        makeAhead: 'Make the sauce in advance',
+        storage: 'Keep refrigerated for up to 3 days',
+        substitutions: ['Use tofu'],
+        variations: ['Add chili flakes']
+      }))
+    })
   })
 
   describe('getRecipe', () => {
@@ -286,7 +329,7 @@ describe('recipeStorageApi', () => {
       expect(axios.put).toHaveBeenCalledWith(
         expect.stringContaining('/api/recipes/test-recipe-id'),
         expect.objectContaining({
-          recipeName: 'Test Recipe'
+          title: 'Test Recipe'
         }),
         expect.objectContaining({
           headers: expect.objectContaining({

--- a/src/services/recipeStorageApi.ts
+++ b/src/services/recipeStorageApi.ts
@@ -4,17 +4,124 @@ import { uploadRecipeImage, deleteRecipeImage } from '../utils/imageStorage'
 import type { Recipe, RecipeTips } from '../types/nutrition'
 import { RecipeUtils } from '@theandiman/recipe-management-shared/dist/types/recipe'
 
-const MANAGEMENT_API_BASE = import.meta.env.VITE_MANAGEMENT_API_URL || ''
+const MANAGEMENT_API_BASE =
+  import.meta.env.VITE_MANAGEMENT_API_URL ||
+  import.meta.env.VITE_STORAGE_API_URL ||
+  ''
 const IS_TEST_MODE = import.meta.env.VITE_TEST_MODE === 'true'
+
+type NutritionPerServing = NonNullable<NonNullable<Recipe['nutritionalInfo']>['perServing']>
+
+type ManagementRecipePayload = Partial<Recipe> & {
+  title?: string
+  prepTime?: number | string
+  cookTime?: number | string
+  nutrition?: NutritionPerServing | null
+  tips?: Record<string, unknown> | RecipeTips | null
+  public?: boolean
+}
 
 const normalizeStringArray = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 
-const normalizeRecipe = (recipe: Recipe): Recipe => {
+const parseTimeToMinutes = (value?: string | number | unknown): number | undefined => {
+  if (value === undefined || value === null) return undefined
+
+  if (typeof value === 'number') {
+    return value > 0 ? Math.floor(value) : undefined
+  }
+
+  const timeStr = String(value).trim()
+  if (!timeStr) return undefined
+
+  const match = timeStr.match(/(\d+)\s*(minute|min|hour|hr)/i)
+  if (match) {
+    const amount = parseInt(match[1], 10)
+    const unit = match[2].toLowerCase()
+    return unit.startsWith('hour') || unit.startsWith('hr') ? amount * 60 : amount
+  }
+
+  const num = parseInt(timeStr, 10)
+  return Number.isNaN(num) || num <= 0 ? undefined : num
+}
+
+const normalizeTipText = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed || undefined
+  }
+
+  const items = normalizeStringArray(value)
+  return items.length ? items.join(' ') : undefined
+}
+
+const normalizeTips = (tips?: Record<string, unknown> | RecipeTips | null): RecipeTips | undefined => {
+  if (!tips || typeof tips !== 'object') {
+    return undefined
+  }
+
+  const normalizedTips: RecipeTips = {}
+  const substitutions = normalizeStringArray((tips as { substitutions?: unknown }).substitutions)
+  const variations = normalizeStringArray((tips as { variations?: unknown }).variations)
+  const makeAhead = normalizeTipText((tips as { makeAhead?: unknown }).makeAhead)
+  const storage = normalizeTipText((tips as { storage?: unknown }).storage)
+  const reheating = normalizeTipText((tips as { reheating?: unknown }).reheating)
+
+  if (substitutions.length) normalizedTips.substitutions = substitutions
+  if (variations.length) normalizedTips.variations = variations
+  if (makeAhead) normalizedTips.makeAhead = makeAhead
+  if (storage) normalizedTips.storage = storage
+  if (reheating) normalizedTips.reheating = reheating
+
+  return Object.keys(normalizedTips).length > 0 ? normalizedTips : undefined
+}
+
+const normalizeRecipe = (recipe: ManagementRecipePayload): Recipe => {
+  const prepTimeMinutes = recipe.prepTimeMinutes ?? parseTimeToMinutes(recipe.prepTime)
+  const cookTimeMinutes = recipe.cookTimeMinutes ?? parseTimeToMinutes(recipe.cookTime)
+  const recipeName =
+    typeof recipe.recipeName === 'string' && recipe.recipeName.trim()
+      ? recipe.recipeName
+      : typeof recipe.title === 'string' && recipe.title.trim()
+        ? recipe.title
+        : 'Untitled Recipe'
+
   const normalized: Recipe = {
     ...recipe,
+    recipeName,
     ingredients: normalizeStringArray(recipe.ingredients),
     instructions: normalizeStringArray(recipe.instructions),
+    servings: RecipeUtils.getServingsAsNumber(recipe.servings ?? 1),
+    source: recipe.source || 'manual',
+  }
+
+  if (prepTimeMinutes !== undefined) {
+    normalized.prepTimeMinutes = prepTimeMinutes
+    if (typeof recipe.prepTime !== 'string') {
+      normalized.prepTime = `${prepTimeMinutes} min`
+    }
+  } else if (typeof recipe.prepTime === 'string') {
+    normalized.prepTime = recipe.prepTime
+  }
+
+  if (cookTimeMinutes !== undefined) {
+    normalized.cookTimeMinutes = cookTimeMinutes
+    if (typeof recipe.cookTime !== 'string') {
+      normalized.cookTime = `${cookTimeMinutes} min`
+    }
+  } else if (typeof recipe.cookTime === 'string') {
+    normalized.cookTime = recipe.cookTime
+  }
+
+  if (recipe.nutritionalInfo) {
+    normalized.nutritionalInfo = recipe.nutritionalInfo
+  } else if (recipe.nutrition && typeof recipe.nutrition === 'object') {
+    normalized.nutritionalInfo = { perServing: recipe.nutrition }
+  }
+
+  const normalizedTips = normalizeTips(recipe.tips)
+  if (normalizedTips) {
+    normalized.tips = normalizedTips
   }
 
   if (Array.isArray(recipe.tags)) {
@@ -25,16 +132,8 @@ const normalizeRecipe = (recipe: Recipe): Recipe => {
     normalized.dietaryRestrictions = normalizeStringArray(recipe.dietaryRestrictions)
   }
 
-  if (recipe.tips) {
-    normalized.tips = {
-      ...recipe.tips,
-      ...(Array.isArray(recipe.tips.substitutions)
-        ? { substitutions: normalizeStringArray(recipe.tips.substitutions) }
-        : {}),
-      ...(Array.isArray(recipe.tips.variations)
-        ? { variations: normalizeStringArray(recipe.tips.variations) }
-        : {}),
-    }
+  if (recipe.isPublic !== undefined || recipe.public !== undefined) {
+    normalized.isPublic = recipe.isPublic ?? Boolean(recipe.public)
   }
 
   return normalized
@@ -42,7 +141,7 @@ const normalizeRecipe = (recipe: Recipe): Recipe => {
 
 const extractRecipes = (payload: unknown): Recipe[] => {
   if (Array.isArray(payload)) {
-    return payload.map((recipe) => normalizeRecipe(recipe as Recipe))
+    return payload.map((recipe) => normalizeRecipe(recipe as ManagementRecipePayload))
   }
 
   if (
@@ -50,7 +149,7 @@ const extractRecipes = (payload: unknown): Recipe[] => {
     typeof payload === 'object' &&
     Array.isArray((payload as { recipes?: unknown }).recipes)
   ) {
-    return ((payload as { recipes: Recipe[] }).recipes || []).map((recipe) => normalizeRecipe(recipe))
+    return ((payload as { recipes: ManagementRecipePayload[] }).recipes || []).map((recipe) => normalizeRecipe(recipe))
   }
 
   return []
@@ -60,24 +159,15 @@ const extractRecipes = (payload: unknown): Recipe[] => {
  * Request DTO for creating a recipe in the management service
  */
 export interface CreateRecipeRequest {
-  recipeName: string
+  title: string
   description?: string
   ingredients: string[]
   instructions: string[]
-  prepTimeMinutes?: number
-  cookTimeMinutes?: number
+  prepTime?: number
+  cookTime?: number
   servings: number
-  nutritionalInfo?: {
-    perServing?: {
-      calories?: number
-      protein?: number
-      carbohydrates?: number
-      fat?: number
-      fiber?: number
-      sodium?: number
-    }
-  }
-  tips?: Record<string, string | string[]> // Backend expects strings for makeAhead/storage/reheating, arrays for substitutions/variations
+  nutrition?: NutritionPerServing
+  tips?: Record<string, string[]>
   imageUrl?: string
   source: string
   tags?: string[]
@@ -88,64 +178,41 @@ export interface CreateRecipeRequest {
  * Convert AI-generated Recipe to CreateRecipeRequest
  */
 const mapRecipeToCreateRequest = (recipe: Recipe): CreateRecipeRequest => {
-  // Parse time strings to minutes (e.g., "30 minutes" -> 30)
-  const parseTimeToMinutes = (time?: string | number | undefined): number | undefined => {
-    if (time === undefined || time === null) return undefined
-    // If it's a number, accept only positive values; treat 0 or negatives as undefined
-    if (typeof time === 'number') {
-      return time > 0 ? Math.floor(time) : undefined
-    }
-    const timeStr = String(time).trim()
-    if (!timeStr) return undefined
-    const match = timeStr.match(/(\d+)\s*(minute|min|hour|hr)/i)
-    if (match) {
-      const value = parseInt(match[1], 10)
-      const unit = match[2].toLowerCase()
-      return unit.startsWith('hour') || unit.startsWith('hr') ? value * 60 : value
-    }
-
-    // Fallback: try to parse a plain number string
-    const num = parseInt(timeStr, 10)
-    return isNaN(num) || num <= 0 ? undefined : num
-  }
-
-  // Convert tips to Map<String, List<String>> format expected by backend
-  const mapTips = (tips?: RecipeTips): Record<string, string | string[]> | undefined => {
+  const mapTips = (tips?: RecipeTips): Record<string, string[]> | undefined => {
     if (!tips) return undefined
-    
-    const result: Record<string, string | string[]> = {}
-    
-    if (tips.substitutions) {
+
+    const result: Record<string, string[]> = {}
+
+    if (tips.substitutions?.length) {
       result.substitutions = tips.substitutions
     }
     if (tips.makeAhead) {
-      result.makeAhead = tips.makeAhead // Keep as string
+      result.makeAhead = [tips.makeAhead]
     }
     if (tips.storage) {
-      result.storage = tips.storage // Keep as string
+      result.storage = [tips.storage]
     }
     if (tips.reheating) {
-      result.reheating = tips.reheating // Keep as string
+      result.reheating = [tips.reheating]
     }
-    if (tips.variations) {
+    if (tips.variations?.length) {
       result.variations = tips.variations
     }
-    
+
     return Object.keys(result).length > 0 ? result : undefined
   }
 
-  // Skip imageUrl if it's a base64 data URL (too large for Firestore)
   const imageUrl = recipe.imageUrl?.startsWith('data:') ? undefined : recipe.imageUrl
 
   return {
-    recipeName: recipe.recipeName,
+    title: recipe.recipeName,
     description: recipe.description,
     ingredients: recipe.ingredients,
     instructions: recipe.instructions,
-    prepTimeMinutes: recipe.prepTimeMinutes ?? parseTimeToMinutes(recipe.prepTime),
-    cookTimeMinutes: recipe.cookTimeMinutes ?? parseTimeToMinutes(recipe.cookTime),
+    prepTime: recipe.prepTimeMinutes ?? parseTimeToMinutes(recipe.prepTime),
+    cookTime: recipe.cookTimeMinutes ?? parseTimeToMinutes(recipe.cookTime),
     servings: RecipeUtils.getServingsAsNumber(recipe.servings),
-    nutritionalInfo: recipe.nutritionalInfo ? { perServing: recipe.nutritionalInfo.perServing } : undefined,
+    nutrition: recipe.nutritionalInfo?.perServing,
     tips: mapTips(recipe.tips),
     imageUrl,
     source: recipe.source || 'ai-generated',

--- a/src/services/userApi.ts
+++ b/src/services/userApi.ts
@@ -2,7 +2,10 @@ import axios from 'axios'
 import { buildApiUrl } from '../utils/apiUtils'
 import type { Recipe } from '../types/nutrition'
 
-const USER_API_BASE = import.meta.env.VITE_MANAGEMENT_API_URL || ''
+const USER_API_BASE =
+  import.meta.env.VITE_MANAGEMENT_API_URL ||
+  import.meta.env.VITE_STORAGE_API_URL ||
+  ''
 const IS_TEST_MODE = import.meta.env.VITE_TEST_MODE === 'true'
 
 export interface UserProfile {


### PR DESCRIPTION
## Summary
- map the management-service recipe payload (`title`, `prepTime`, `cookTime`, `nutrition`) into the shared frontend recipe shape
- send the backend request fields the management service actually expects when saving/updating recipes
- restore the `VITE_STORAGE_API_URL` fallback and pass `VITE_MANAGEMENT_API_URL` in CI/deploy workflows

## Root cause
The deployed frontend was switched to the management service, but two contract mismatches remained:
1. production still relied on the older `VITE_STORAGE_API_URL` secret name, while the app was reading only `VITE_MANAGEMENT_API_URL`; and
2. the management service returns `title`/`prepTime`/`nutrition`, while the frontend expects `recipeName`/`prepTimeMinutes`/`nutritionalInfo`.

## Verification
- `npm run test -- src/services/recipeStorageApi.test.ts src/features/recipes/SavedRecipesContext.test.tsx src/features/users/UserProfilePage.test.tsx --run`
- `npm run build`