### PR TITLE
Fix inline AI suggestions API base URL fallback

### DIFF
--- a/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
@@ -7,8 +7,11 @@ vi.mock('../../../../utils/authApi', () => ({
   postWithAuth: vi.fn(),
 }))
 vi.mock('../../../../utils/apiUtils', () => ({
-  buildApiUrl: (_base: string, endpoint: string) => endpoint,
+  buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
 }))
+
+import { buildApiUrl } from '../../../../utils/apiUtils'
+const mockBuildApiUrl = vi.mocked(buildApiUrl)
 
 import { postWithAuth } from '../../../../utils/authApi'
 
@@ -188,5 +191,34 @@ describe('useAISuggestions', () => {
     expect(events).toContain('ai_suggestions_fetched')
 
     window.removeEventListener('ai:suggestions', listener)
+  })
+
+  describe('API base URL resolution', () => {
+    it('uses VITE_AI_API_URL when set, preferring it over VITE_API_URL', async () => {
+      vi.stubEnv('VITE_AI_API_URL', 'https://ai.example.com')
+
+      mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Test' })
+      })
+
+      expect(mockBuildApiUrl).toHaveBeenCalledWith('https://ai.example.com', '/api/recipes/suggest-fields')
+      vi.unstubAllEnvs()
+    })
+
+    it('falls back to VITE_API_URL when VITE_AI_API_URL is absent', async () => {
+      // VITE_AI_API_URL is not set in the test environment, so the hook falls back to VITE_API_URL
+      mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Test' })
+      })
+
+      const expectedBase = import.meta.env.VITE_API_URL || ''
+      expect(mockBuildApiUrl).toHaveBeenCalledWith(expectedBase, '/api/recipes/suggest-fields')
+    })
   })
 })

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -74,7 +74,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     const startTime = Date.now()
 
     try {
-      const apiBase = import.meta.env.VITE_API_URL || ''
+      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
       const url = buildApiUrl(apiBase, '/api/recipes/suggest-fields')
       const res = await postWithAuth(url, request)
       const data = res.data as { suggestions: FieldSuggestion[] }

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -74,7 +74,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     const startTime = Date.now()
 
     try {
-      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
+      const apiBase = import.meta.env.VITE_AI_API_URL ?? import.meta.env.VITE_API_URL ?? ''
       const url = buildApiUrl(apiBase, '/api/recipes/suggest-fields')
       const res = await postWithAuth(url, request)
       const data = res.data as { suggestions: FieldSuggestion[] }


### PR DESCRIPTION
Summary: update useAISuggestions to prefer VITE_AI_API_URL and fall back to VITE_API_URL. Why: inline suggestions can fail when AI traffic is routed via VITE_AI_API_URL but this hook used only VITE_API_URL. Test: npm run build currently fails due to pre-existing unused icons in src/features/recipes/RecipeDetail.tsx, unrelated to this change. Changed file: src/features/recipes/hooks/useAISuggestions.ts.