### PR TITLE
feat(ai): on-demand AI enhancement button replaces auto-trigger

### DIFF
--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { StepIndicator } from './StepIndicator'
 import { RecipeFormSteps } from './RecipeFormSteps'
 
@@ -270,16 +270,6 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     return null
   }, [localAuditLog])
 
-  // Fetch suggestions once when the recipe title is available (first meaningful state)
-  const suggestionFetched = useRef(false)
-  useEffect(() => {
-    if (!suggestionFetched.current && title.trim().length > 2) {
-      suggestionFetched.current = true
-      fetchSuggestions(buildSuggestionRequest())
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [title])
-
   // Wrap setters to allow passing previousValue for audit trail
   const fieldSetters: Partial<Record<string, (value: string) => void>> = {
     recipeName: setTitle,
@@ -320,8 +310,11 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     instructions: instructions.filter(i => i.trim()),
   })
 
+  const handleEnhanceWithAI = () => {
+    fetchSuggestions(buildSuggestionRequest())
+  }
+
   const handleRetrySuggestions = () => {
-    suggestionFetched.current = false
     fetchSuggestions(buildSuggestionRequest())
   }
 
@@ -338,6 +331,22 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               Step {currentStep} of {totalSteps}: {steps[currentStep - 1].title}
             </p>
           </div>
+          {currentStep !== 5 && (
+            <button
+              type="button"
+              onClick={handleEnhanceWithAI}
+              disabled={suggestionStatus === 'loading'}
+              aria-label="Enhance recipe with AI"
+              className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {suggestionStatus === 'loading' ? (
+                <span className="animate-spin">⏳</span>
+              ) : (
+                <span aria-hidden="true">✨</span>
+              )}
+              Enhance with AI
+            </button>
+          )}
         </div>
 
         {/* Step Progress Indicator - Horizontal scroll on mobile */}

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import { RecipeFormLayout } from '../RecipeFormLayout'
+import type { ComponentProps } from 'react'
+
+vi.mock('../../../../utils/authApi', () => ({
+  postWithAuth: vi.fn(),
+}))
+vi.mock('../../../../utils/apiUtils', () => ({
+  buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
+}))
+
+import { postWithAuth } from '../../../../utils/authApi'
+const mockPostWithAuth = vi.mocked(postWithAuth)
+
+const mockIngredients = [{ quantity: '', unit: '', item: '' }]
+const mockSteps = [
+  { number: 1, title: 'Basic Info', icon: '📝' },
+  { number: 2, title: 'Ingredients', icon: '🥕' },
+  { number: 3, title: 'Instructions', icon: '📋' },
+  { number: 4, title: 'Additional Info', icon: '⏱️' },
+  { number: 5, title: 'Review', icon: '✅' },
+]
+
+function makeProps(overrides: Partial<ComponentProps<typeof RecipeFormLayout>> = {}): ComponentProps<typeof RecipeFormLayout> {
+  return {
+    mode: 'create',
+    currentStep: 1,
+    totalSteps: 5,
+    steps: mockSteps,
+    goToStep: vi.fn(),
+    goToNextStep: vi.fn(),
+    goToPreviousStep: vi.fn(),
+    canGoNext: true,
+    canGoPrevious: false,
+    stepsWithErrors: new Set(),
+    title: '',
+    setTitle: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    prepTime: '',
+    setPrepTime: vi.fn(),
+    cookTime: '',
+    setCookTime: vi.fn(),
+    servings: '',
+    setServings: vi.fn(),
+    imagePreview: null,
+    handleImageUpload: vi.fn(),
+    removeImage: vi.fn(),
+    ingredients: mockIngredients,
+    addIngredient: vi.fn(),
+    updateIngredient: vi.fn(),
+    removeIngredient: vi.fn(),
+    instructions: [''],
+    addInstruction: vi.fn(),
+    updateInstruction: vi.fn(),
+    removeInstruction: vi.fn(),
+    tags: [],
+    tagInput: '',
+    setTagInput: vi.fn(),
+    addTag: vi.fn(),
+    removeTag: vi.fn(),
+    dietaryRestrictions: [],
+    dietaryInput: '',
+    setDietaryInput: vi.fn(),
+    addDietaryRestriction: vi.fn(),
+    removeDietaryRestriction: vi.fn(),
+    fieldErrors: {},
+    clearFieldError: vi.fn(),
+    setFieldErrors: vi.fn(),
+    setStepsWithErrors: vi.fn(),
+    saveLoading: false,
+    saveError: null,
+    setSaveError: vi.fn(),
+    handleSubmit: vi.fn(),
+    handleCancel: vi.fn(),
+    ...overrides,
+  }
+}
+
+const renderWithRouter = (props: ComponentProps<typeof RecipeFormLayout>) =>
+  render(<BrowserRouter><RecipeFormLayout {...props} /></BrowserRouter>)
+
+describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('does NOT auto-fetch AI suggestions when title is typed', async () => {
+    // Even with a title longer than 2 chars, no fetch should happen without a button click
+    renderWithRouter(makeProps({ title: 'My Recipe' }))
+    // Give React time to run any effects
+    await new Promise(r => setTimeout(r, 50))
+    expect(mockPostWithAuth).not.toHaveBeenCalled()
+  })
+
+  it('renders the "Enhance with AI" button on non-preview steps', () => {
+    renderWithRouter(makeProps())
+    expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render the "Enhance with AI" button on step 5 (preview)', () => {
+    renderWithRouter(makeProps({ currentStep: 5 }))
+    expect(screen.queryByRole('button', { name: /Enhance recipe with AI/i })).not.toBeInTheDocument()
+  })
+
+  it('calls AI suggestions API when "Enhance with AI" is clicked', async () => {
+    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+
+    renderWithRouter(makeProps({ title: 'Pasta' }))
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    await waitFor(() => expect(mockPostWithAuth).toHaveBeenCalledOnce())
+    expect(mockPostWithAuth).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ recipeName: 'Pasta' })
+    )
+  })
+
+  it('shows the suggestion panel only after the button is clicked', async () => {
+    mockPostWithAuth.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'description', suggestedValue: 'A tasty dish', reason: 'Empty' },
+        ],
+      },
+    } as any)
+
+    renderWithRouter(makeProps({ title: 'Pasta' }))
+    // Panel is hidden before click
+    expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
+    )
+  })
+
+  it('disables the button while a fetch is in progress', async () => {
+    let resolvePost: (v: any) => void
+    mockPostWithAuth.mockImplementationOnce(() => new Promise(r => { resolvePost = r }))
+
+    renderWithRouter(makeProps())
+    const btn = screen.getByRole('button', { name: /Enhance recipe with AI/i })
+    fireEvent.click(btn)
+
+    await waitFor(() => expect(btn).toBeDisabled())
+
+    resolvePost!({ data: { suggestions: [] } })
+    await waitFor(() => expect(btn).not.toBeDisabled())
+  })
+})

--- a/tests/ai-authoring.spec.ts
+++ b/tests/ai-authoring.spec.ts
@@ -85,11 +85,13 @@ async function mockNormalizeIngredients(page: Page) {
   })
 }
 
-/** Fill the recipe title on step 1. Triggers the AI suggestion fetch once the title is > 2 chars. */
+/** Fill the recipe title on step 1, then click the Enhance with AI button to trigger suggestions. */
 async function fillRecipeTitle(page: Page, title = 'Test Recipe') {
   await page.goto('/dashboard/create')
   await page.waitForLoadState('networkidle')
   await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill(title)
+  // AI enhancement is now on-demand — click the button to fetch suggestions
+  await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -225,7 +227,9 @@ test.describe('AI-assisted authoring — field suggestions', () => {
     await expect(page.getByText(/Step 1 of 5/i)).toBeVisible()
 
     await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill('My Test Cake')
-    // Wait for the AI suggestion panel to load (auto-triggered by title entry)
+    // Click Enhance with AI to request suggestions (on-demand trigger)
+    await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
+    // Wait for the AI suggestion panel to load
     const panel = page.getByRole('region', { name: /AI field suggestions/i })
     await expect(panel).toBeVisible({ timeout: 8000 })
 
@@ -276,8 +280,9 @@ test.describe('AI-assisted authoring — edit flow', () => {
     await page.goto('/dashboard/create')
     await page.waitForLoadState('networkidle')
 
-    // Fill a title to trigger suggestion fetch
+    // Fill a title and click Enhance with AI to trigger suggestion fetch
     await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill('Existing Cake')
+    await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
     const panel = page.getByRole('region', { name: /AI field suggestions/i })
     await expect(panel).toBeVisible({ timeout: 8000 })
 


### PR DESCRIPTION
## Summary
Replace the auto-triggered AI suggestion fetch with an explicit **✨ Enhance with AI** button in the recipe form header.

## Problem
AI suggestions fired automatically as soon as the user typed a title (length > 2). This was intrusive and took control away from the user.

## Solution
- Removed the `useEffect` / `suggestionFetched` ref that auto-fetched suggestions
- Added an **Enhance with AI ✨** button in the form header (visible on all non-preview steps)
- Button is disabled while a fetch is in progress (shows spinner)
- Panel remains hidden (`status === 'idle'`) until user clicks the button

## Tests
New `RecipeFormLayout.test.tsx` covering:
- No auto-fetch when title changes
- Button renders on non-preview steps
- Button hidden on step 5 (preview)
- Clicking button calls the AI API
- Panel appears only after button click
- Button disabled during fetch, re-enabled after

## Closes
Closes theandiman/recipe-management#35