### PR TITLE
feat(ai): add AI enhancement affordances to SimpleCreateRecipe

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -232,3 +232,26 @@ describe('SimpleCreateRecipe', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard/recipes')
   })
 })
+
+// ─── AI Enhancement (issue #36) ──────────────────────────────────────────────
+
+describe('AI Enhancement', () => {
+  beforeEach(() => {
+    vi.mock('../../utils/authApi', () => ({
+      postWithAuth: vi.fn(),
+    }))
+    vi.mock('../../utils/apiUtils', () => ({
+      buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
+    }))
+  })
+
+  it('renders the "Enhance with AI" button', () => {
+    renderWithRouter(<SimpleCreateRecipe />)
+    expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
+  })
+
+  it('does NOT show the AI suggestion panel before the button is clicked', () => {
+    renderWithRouter(<SimpleCreateRecipe />)
+    expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -19,6 +19,14 @@ vi.mock('../../services/recipeStorageApi', () => ({
   ),
 }))
 
+vi.mock('../../utils/authApi', () => ({
+  postWithAuth: vi.fn(),
+}))
+
+vi.mock('../../utils/apiUtils', () => ({
+  buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
+}))
+
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
@@ -236,15 +244,6 @@ describe('SimpleCreateRecipe', () => {
 // ─── AI Enhancement (issue #36) ──────────────────────────────────────────────
 
 describe('AI Enhancement', () => {
-  beforeEach(() => {
-    vi.mock('../../utils/authApi', () => ({
-      postWithAuth: vi.fn(),
-    }))
-    vi.mock('../../utils/apiUtils', () => ({
-      buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
-    }))
-  })
-
   it('renders the "Enhance with AI" button', () => {
     renderWithRouter(<SimpleCreateRecipe />)
     expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
@@ -253,5 +252,19 @@ describe('AI Enhancement', () => {
   it('does NOT show the AI suggestion panel before the button is clicked', () => {
     renderWithRouter(<SimpleCreateRecipe />)
     expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
+  })
+
+  it('shows the AI suggestion panel in loading state when "Enhance with AI" is clicked', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    // Keep the request pending so we can observe the loading state
+    vi.mocked(postWithAuth).mockReturnValue(new Promise(() => {}))
+
+    renderWithRouter(<SimpleCreateRecipe />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
+    })
   })
 })

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -8,6 +8,8 @@ import { IngredientInput } from '../../components/IngredientInput'
 import { UI_STYLES } from '../../utils/uiStyles'
 import { clampedNumericHandler } from '../../utils/formUtils'
 import { useSimpleCreateSections } from './hooks/useSimpleCreateSections'
+import { useAISuggestions } from './hooks/useAISuggestions'
+import { AISuggestionPanel } from './components/AISuggestionPanel'
 
 export const SimpleCreateRecipe: React.FC = () => {
   const navigate = useNavigate()
@@ -41,12 +43,60 @@ export const SimpleCreateRecipe: React.FC = () => {
     navigate('/dashboard/recipes')
   }, [navigate])
 
+  const {
+    visibleSuggestions,
+    status: suggestionStatus,
+    error: suggestionError,
+    fetchSuggestions,
+    applySuggestion,
+    dismissSuggestion,
+  } = useAISuggestions()
+
+  const buildSuggestionRequest = () => ({
+    recipeName: form.title || undefined,
+    description: form.description || undefined,
+    prepTime: form.prepTime || undefined,
+    cookTime: form.cookTime || undefined,
+    servings: form.servings || undefined,
+    tags: form.tags.length > 0 ? form.tags : undefined,
+    ingredients: form.ingredients.filter(i => i.item.trim()).map(i =>
+      [i.quantity, i.unit, i.item].filter(Boolean).join(' ')
+    ),
+    instructions: form.instructions.filter(i => i.trim()),
+  })
+
+  const fieldSetters: Partial<Record<string, (value: string) => void>> = {
+    recipeName: Object.assign(form.setTitle, { currentValue: form.title }),
+    description: Object.assign(form.setDescription, { currentValue: form.description }),
+    prepTime: Object.assign(form.setPrepTime, { currentValue: form.prepTime }),
+    cookTime: Object.assign(form.setCookTime, { currentValue: form.cookTime }),
+    servings: Object.assign(form.setServings, { currentValue: form.servings }),
+  }
+
+  const handleEnhanceWithAI = () => {
+    fetchSuggestions(buildSuggestionRequest())
+  }
+
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
       {/* Header */}
       <div className="mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Create Recipe</h1>
+          <button
+            type="button"
+            onClick={handleEnhanceWithAI}
+            disabled={suggestionStatus === 'loading'}
+            aria-label="Enhance recipe with AI"
+            className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {suggestionStatus === 'loading' ? (
+              <span className="animate-spin">⏳</span>
+            ) : (
+              <span aria-hidden="true">✨</span>
+            )}
+            Enhance with AI
+          </button>
         </div>
 
         {/* Entry-point mode toggle */}
@@ -106,6 +156,16 @@ export const SimpleCreateRecipe: React.FC = () => {
           </button>
         </div>
       )}
+
+      <AISuggestionPanel
+        suggestions={visibleSuggestions}
+        status={suggestionStatus}
+        error={suggestionError}
+        onApply={applySuggestion}
+        onDismiss={dismissSuggestion}
+        fieldSetters={fieldSetters}
+        onRetry={handleEnhanceWithAI}
+      />
 
       <form onSubmit={handleSubmit} noValidate className="space-y-6">
         {/* ─── Required: Title ─── */}

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useRecipeForm } from './hooks/useRecipeForm'
 import { useRecipeValidation } from './hooks/useRecipeValidation'
@@ -65,13 +65,21 @@ export const SimpleCreateRecipe: React.FC = () => {
     instructions: form.instructions.filter(i => i.trim()),
   })
 
-  const fieldSetters: Partial<Record<string, (value: string) => void>> = {
-    recipeName: Object.assign(form.setTitle, { currentValue: form.title }),
-    description: Object.assign(form.setDescription, { currentValue: form.description }),
-    prepTime: Object.assign(form.setPrepTime, { currentValue: form.prepTime }),
-    cookTime: Object.assign(form.setCookTime, { currentValue: form.cookTime }),
-    servings: Object.assign(form.setServings, { currentValue: form.servings }),
-  }
+  const fieldSetters: Partial<Record<string, (value: string) => void>> = useMemo(() => ({
+    recipeName: form.setTitle,
+    description: form.setDescription,
+    prepTime: form.setPrepTime,
+    cookTime: form.setCookTime,
+    servings: form.setServings,
+  }), [form.setTitle, form.setDescription, form.setPrepTime, form.setCookTime, form.setServings])
+
+  const currentValues: Partial<Record<string, string>> = useMemo(() => ({
+    recipeName: form.title,
+    description: form.description,
+    prepTime: form.prepTime,
+    cookTime: form.cookTime,
+    servings: form.servings,
+  }), [form.title, form.description, form.prepTime, form.cookTime, form.servings])
 
   const handleEnhanceWithAI = () => {
     fetchSuggestions(buildSuggestionRequest())
@@ -164,6 +172,7 @@ export const SimpleCreateRecipe: React.FC = () => {
         onApply={applySuggestion}
         onDismiss={dismissSuggestion}
         fieldSetters={fieldSetters}
+        currentValues={currentValues}
         onRetry={handleEnhanceWithAI}
       />
 

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -10,6 +10,8 @@ interface AISuggestionPanelProps {
   onDismiss: (field: string) => void
   /** Maps field names to their corresponding form setter functions */
   fieldSetters: Partial<Record<string, (value: string) => void>>
+  /** Current form values keyed by field name — used to record "before" state for the audit trail */
+  currentValues?: Partial<Record<string, string>>
   onRetry?: () => void
 }
 
@@ -29,6 +31,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   onApply,
   onDismiss,
   fieldSetters,
+  currentValues,
   onRetry,
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(true)
@@ -126,10 +129,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                         <button
                           type="button"
                           onClick={() => {
-                            // Get the current value for audit trail
-                            let previousValue = ''
-                            if ('currentValue' in setter) previousValue = (setter as any).currentValue || ''
-                            // For other fields, pass empty string or implement as needed
+                            const previousValue = currentValues?.[suggestion.field] ?? ''
                             onApply(suggestion.field, setter, previousValue)
                           }}
                           className="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-500 hover:bg-amber-600 text-white transition-colors"


### PR DESCRIPTION
## Summary
Add the same **✨ Enhance with AI** experience to the Quick-entry (SimpleCreateRecipe) form, so all three authoring surfaces — guided create, quick create, and edit — expose consistent AI affordances.

## Problem
`SimpleCreateRecipe` had no AI integration. Users switching to quick entry lost access to AI assistance entirely.

## Solution
- Import `useAISuggestions` and `AISuggestionPanel`
- Wire `fieldSetters` for recipeName, description, prepTime, cookTime, servings
- Add **Enhance with AI ✨** button in the form header (same pattern as guided create/edit — no auto-trigger)
- `AISuggestionPanel` placed between the error banner and the form; hidden (`idle`) until user clicks

## Tests
New tests in `SimpleCreateRecipe.test.tsx` (AI Enhancement block):
- Enhance with AI button renders
- Suggestion panel not shown until button clicked

## Closes
Closes theandiman/recipe-management#36