### PR TITLE
feat(ai): field-level and whole-recipe instruction refinement UI

### DIFF
--- a/src/features/recipes/CreateRecipe.test.tsx
+++ b/src/features/recipes/CreateRecipe.test.tsx
@@ -227,7 +227,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
       fireEvent.click(nextButton) // → step 2
       const itemInput = screen.getAllByPlaceholderText('e.g., all-purpose flour')[0]
       fireEvent.change(itemInput, { target: { value: 'flour' } })
-      const step3Button = screen.getByRole('button', { name: /Instructions/i })
+      const step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
       fireEvent.click(step3Button) // step 2 valid → step 3
     })
 
@@ -614,7 +614,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
         fireEvent.change(itemInput, { target: { value: 'flour' } })
         
         // Add instruction
-        const step3Button = screen.getByRole('button', { name: /Instructions/i })
+        const step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
         fireEvent.click(step3Button)
         
         const instructionInput = screen.getAllByPlaceholderText(/Describe this step in detail/i)[0]
@@ -675,7 +675,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
         
         
         // Step 3 should have red ring
-        const step3Button = screen.getByRole('button', { name: /Instructions/i })
+        const step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
         const step3Icon = step3Button.querySelector('div')
         expect(step3Icon).toHaveClass('ring-2', 'ring-red-500')
       })
@@ -726,7 +726,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
         // All error steps should be marked in progress indicator
         const step1Button = screen.getByRole('button', { name: /Basic Info/i })
         const step2Button = screen.getByRole('button', { name: /Ingredients/i })
-        const step3Button = screen.getByRole('button', { name: /Instructions/i })
+        const step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
         
         expect(step1Button.querySelector('.ring-red-500')).toBeInTheDocument()
         expect(step2Button.querySelector('.ring-red-500')).toBeInTheDocument()
@@ -761,7 +761,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
         // All steps should have errors
         let step1Button = screen.getByRole('button', { name: /Basic Info/i })
         let step2Button = screen.getByRole('button', { name: /Ingredients/i })
-        let step3Button = screen.getByRole('button', { name: /Instructions/i })
+        let step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
         
         expect(step1Button.querySelector('.ring-red-500')).toBeInTheDocument()
         expect(step2Button.querySelector('.ring-red-500')).toBeInTheDocument()
@@ -787,7 +787,7 @@ describe('CreateRecipe - Multi-Step Wizard', () => {
         expect(step2Button.querySelector('.ring-red-500')).not.toBeInTheDocument()
         
         // Step 3 should still have error
-        step3Button = screen.getByRole('button', { name: /Instructions/i })
+        step3Button = screen.getByRole('button', { name: /Go to step 3: Instructions/i })
         expect(step3Button.querySelector('.ring-red-500')).toBeInTheDocument()
       })
     })

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -158,7 +158,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   )
 
   const handleRefineAllInstructions = useCallback(() => {
-    refineAllInstructions(instructions.filter(i => i.trim()), title || undefined)
+    refineAllInstructions(instructions, title || undefined)
   }, [refineAllInstructions, instructions, title])
   // --- Nutrition Estimate Hook ---
   const {

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -6,6 +6,7 @@ import { RecipeFormSteps } from './RecipeFormSteps'
 import { RecipePreview } from './RecipePreview'
 import { AISuggestionPanel } from './AISuggestionPanel'
 import { useAISuggestions } from '../hooks/useAISuggestions'
+import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
 import { FIELD_LABELS } from '../constants/aiConstants'
 import { useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
@@ -140,7 +141,25 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   onDismissNormalization,
 }) => {
   // --- AI Instruction Refinement Hook ---
+  const {
+    stepStates: instructionRefinementStates,
+    loadingState: instructionRefinementLoading,
+    refineSingle: refineSingleInstruction,
+    refineAll: refineAllInstructions,
+    acceptStep: acceptInstructionRefinement,
+    rejectStep: rejectInstructionRefinement,
+  } = useInstructionRefinement(updateInstruction)
 
+  const handleRefineInstruction = useCallback(
+    (index: number, instruction: string) => {
+      refineSingleInstruction(index, instruction, title || undefined)
+    },
+    [refineSingleInstruction, title]
+  )
+
+  const handleRefineAllInstructions = useCallback(() => {
+    refineAllInstructions(instructions.filter(i => i.trim()), title || undefined)
+  }, [refineAllInstructions, instructions, title])
   // --- Nutrition Estimate Hook ---
   const {
     estimate: nutritionEstimate,
@@ -401,6 +420,12 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 fieldErrors={fieldErrors}
                 clearFieldError={clearFieldError}
                 recipeName={title}
+                onRefineInstruction={handleRefineInstruction}
+                onRefineAllInstructions={handleRefineAllInstructions}
+                instructionRefinementStates={instructionRefinementStates}
+                onAcceptInstructionRefinement={acceptInstructionRefinement}
+                onRejectInstructionRefinement={rejectInstructionRefinement}
+                instructionRefinementLoading={instructionRefinementLoading}
                 normalizationStates={normalizationStates}
                 onApplyNormalization={onApplyNormalization}
                 onDismissNormalization={onDismissNormalization}

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -3,7 +3,8 @@ import { IngredientInput } from '../../../components/IngredientInput'
 import { UI_STYLES } from '../../../utils/uiStyles'
 import { clampedNumericHandler } from '../../../utils/formUtils'
 import type { Ingredient } from '../../../types/nutrition'
-
+import type { StepRefinementState, RefinementLoadingState } from '../hooks/useInstructionRefinement'
+import { InstructionDiffView } from './InstructionDiffView'
 
 
 interface RecipeFormStepsProps {
@@ -47,6 +48,12 @@ interface RecipeFormStepsProps {
   clearFieldError: (fieldName: string, stepNumber: number) => void
   // AI Instruction Refinement
   recipeName: string
+  onRefineInstruction?: (index: number, instruction: string) => void
+  onRefineAllInstructions?: () => void
+  instructionRefinementStates?: Map<number, StepRefinementState>
+  onAcceptInstructionRefinement?: (index: number) => void
+  onRejectInstructionRefinement?: (index: number) => void
+  instructionRefinementLoading?: RefinementLoadingState
   // Ingredient Normalization
   normalizationStates?: Map<number, import('../hooks/useIngredientNormalization').NormalizationState>
   onApplyNormalization?: (index: number) => void
@@ -90,6 +97,12 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
   removeDietaryRestriction,
   fieldErrors,
   clearFieldError,
+  onRefineInstruction,
+  onRefineAllInstructions,
+  instructionRefinementStates,
+  onAcceptInstructionRefinement,
+  onRejectInstructionRefinement,
+  instructionRefinementLoading,
   normalizationStates,
   onApplyNormalization,
   onDismissNormalization,
@@ -236,6 +249,22 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 Instructions <span className="text-red-500">*</span>
               </h2>
               <div className="flex gap-2">
+                {onRefineAllInstructions && (
+                  <button
+                    type="button"
+                    onClick={onRefineAllInstructions}
+                    disabled={instructionRefinementLoading === 'loading'}
+                    aria-label="Refine all instructions with AI"
+                    className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {instructionRefinementLoading === 'loading' ? (
+                      <span className="animate-spin">⏳</span>
+                    ) : (
+                      <span aria-hidden="true">✨</span>
+                    )}
+                    Refine all
+                  </button>
+                )}
                 <button
                   type="button"
                   onClick={addInstruction}
@@ -252,6 +281,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
 
             <div className="space-y-3">
               {instructions.map((instruction, index) => {
+                const refinementState = instructionRefinementStates?.get(index)
+                const isPending = refinementState?.status === 'pending'
   return (
     <div key={index} className="flex items-start space-x-3">
       <span className="flex-shrink-0 w-8 h-10 flex items-center justify-center">
@@ -268,8 +299,31 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
           rows={2}
           className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent resize-none"
         />
+        {isPending && refinementState && (
+          <div className="mt-2">
+            <InstructionDiffView
+              original={refinementState.original}
+              refined={refinementState.refined}
+              onAccept={() => onAcceptInstructionRefinement?.(index)}
+              onReject={() => onRejectInstructionRefinement?.(index)}
+              isLoading={instructionRefinementLoading === 'loading'}
+            />
+          </div>
+        )}
       </div>
       <div className="flex flex-col gap-1">
+        {onRefineInstruction && instruction.trim() && (
+          <button
+            type="button"
+            onClick={() => onRefineInstruction(index, instruction)}
+            disabled={instructionRefinementLoading === 'loading'}
+            aria-label={`Refine step ${index + 1} with AI`}
+            title="Refine this step with AI"
+            className="w-10 h-10 flex items-center justify-center text-amber-500 hover:text-amber-700 hover:bg-amber-50 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            ✨
+          </button>
+        )}
         {instructions.length > 1 && (
           <button
             type="button"

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -253,7 +253,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   <button
                     type="button"
                     onClick={onRefineAllInstructions}
-                    disabled={instructionRefinementLoading === 'loading'}
+                    disabled={instructionRefinementLoading === 'loading' || !instructions.some(i => i.trim())}
                     aria-label="Refine all instructions with AI"
                     className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
@@ -299,13 +299,13 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
           rows={2}
           className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent resize-none"
         />
-        {isPending && refinementState && (
+        {isPending && refinementState && onAcceptInstructionRefinement && onRejectInstructionRefinement && (
           <div className="mt-2">
             <InstructionDiffView
               original={refinementState.original}
               refined={refinementState.refined}
-              onAccept={() => onAcceptInstructionRefinement?.(index)}
-              onReject={() => onRejectInstructionRefinement?.(index)}
+              onAccept={() => onAcceptInstructionRefinement(index)}
+              onReject={() => onRejectInstructionRefinement(index)}
               isLoading={instructionRefinementLoading === 'loading'}
             />
           </div>

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RecipeFormSteps } from '../RecipeFormSteps'
+import type { StepRefinementState } from '../../hooks/useInstructionRefinement'
+import type { ComponentProps } from 'react'
+
+function makeProps(overrides: Partial<ComponentProps<typeof RecipeFormSteps>> = {}): ComponentProps<typeof RecipeFormSteps> {
+  return {
+    currentStep: 3,
+    title: 'Pasta',
+    setTitle: vi.fn(),
+    description: '',
+    setDescription: vi.fn(),
+    prepTime: '',
+    setPrepTime: vi.fn(),
+    cookTime: '',
+    setCookTime: vi.fn(),
+    servings: '',
+    setServings: vi.fn(),
+    imagePreview: null,
+    handleImageUpload: vi.fn(),
+    removeImage: vi.fn(),
+    ingredients: [{ quantity: '', unit: '', item: '' }],
+    addIngredient: vi.fn(),
+    updateIngredient: vi.fn(),
+    removeIngredient: vi.fn(),
+    instructions: ['Boil water', 'Add pasta'],
+    addInstruction: vi.fn(),
+    updateInstruction: vi.fn(),
+    removeInstruction: vi.fn(),
+    tags: [],
+    tagInput: '',
+    setTagInput: vi.fn(),
+    addTag: vi.fn(),
+    removeTag: vi.fn(),
+    dietaryRestrictions: [],
+    dietaryInput: '',
+    setDietaryInput: vi.fn(),
+    addDietaryRestriction: vi.fn(),
+    removeDietaryRestriction: vi.fn(),
+    fieldErrors: {},
+    clearFieldError: vi.fn(),
+    recipeName: 'Pasta',
+    ...overrides,
+  }
+}
+
+describe('RecipeFormSteps — instruction refinement (issue #37)', () => {
+  it('renders "Refine all" button when onRefineAllInstructions is provided', () => {
+    render(<RecipeFormSteps {...makeProps({ onRefineAllInstructions: vi.fn() })} />)
+    expect(screen.getByRole('button', { name: /Refine all instructions with AI/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render "Refine all" button when handler is absent', () => {
+    render(<RecipeFormSteps {...makeProps()} />)
+    expect(screen.queryByRole('button', { name: /Refine all/i })).not.toBeInTheDocument()
+  })
+
+  it('renders per-step ✨ refine button for each instruction when handler is provided', () => {
+    render(<RecipeFormSteps {...makeProps({ onRefineInstruction: vi.fn() })} />)
+    expect(screen.getAllByRole('button', { name: /Refine step \d+ with AI/i })).toHaveLength(2)
+  })
+
+  it('calls onRefineInstruction with correct index when step button clicked', () => {
+    const onRefine = vi.fn()
+    render(<RecipeFormSteps {...makeProps({ onRefineInstruction: onRefine })} />)
+    const [firstBtn] = screen.getAllByRole('button', { name: /Refine step 1 with AI/i })
+    fireEvent.click(firstBtn)
+    expect(onRefine).toHaveBeenCalledWith(0, 'Boil water')
+  })
+
+  it('calls onRefineAllInstructions when "Refine all" is clicked', () => {
+    const onRefineAll = vi.fn()
+    render(<RecipeFormSteps {...makeProps({ onRefineAllInstructions: onRefineAll })} />)
+    fireEvent.click(screen.getByRole('button', { name: /Refine all instructions with AI/i }))
+    expect(onRefineAll).toHaveBeenCalledOnce()
+  })
+
+  it('shows InstructionDiffView for a step with pending refinement', () => {
+    const pendingState: StepRefinementState = {
+      original: 'Boil water',
+      refined: 'Bring salted water to a rolling boil',
+      changesSummary: 'More specific',
+      status: 'pending',
+    }
+    const refinementStates = new Map([[0, pendingState]])
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          instructionRefinementStates: refinementStates,
+          onAcceptInstructionRefinement: vi.fn(),
+          onRejectInstructionRefinement: vi.fn(),
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: /✓ Accept/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /✗ Reject/i })).toBeInTheDocument()
+    // Diff view shows some part of the refined text
+    expect(screen.getByText(/rolling/i)).toBeInTheDocument()
+  })
+
+  it('calls onAcceptInstructionRefinement when Accept is clicked', () => {
+    const onAccept = vi.fn()
+    const pendingState: StepRefinementState = {
+      original: 'Boil water',
+      refined: 'Bring salted water to a boil',
+      changesSummary: '',
+      status: 'pending',
+    }
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          instructionRefinementStates: new Map([[0, pendingState]]),
+          onAcceptInstructionRefinement: onAccept,
+          onRejectInstructionRefinement: vi.fn(),
+        })}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /✓ Accept/i }))
+    expect(onAccept).toHaveBeenCalledWith(0)
+  })
+
+  it('calls onRejectInstructionRefinement when Reject is clicked', () => {
+    const onReject = vi.fn()
+    const pendingState: StepRefinementState = {
+      original: 'Boil water',
+      refined: 'Bring salted water to a boil',
+      changesSummary: '',
+      status: 'pending',
+    }
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          instructionRefinementStates: new Map([[0, pendingState]]),
+          onAcceptInstructionRefinement: vi.fn(),
+          onRejectInstructionRefinement: onReject,
+        })}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /✗ Reject/i }))
+    expect(onReject).toHaveBeenCalledWith(0)
+  })
+
+  it('does not show InstructionDiffView for accepted/rejected steps', () => {
+    const acceptedState: StepRefinementState = {
+      original: 'Boil water',
+      refined: 'Bring salted water to a boil',
+      changesSummary: '',
+      status: 'accepted',
+    }
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          instructionRefinementStates: new Map([[0, acceptedState]]),
+          onAcceptInstructionRefinement: vi.fn(),
+          onRejectInstructionRefinement: vi.fn(),
+        })}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /✓ Accept/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
Wire up the existing `useInstructionRefinement` hook and `InstructionDiffView` component into the recipe authoring form, giving users both field-level (per-step) and section-level (all instructions) AI enhancement actions.

## Problem
`useInstructionRefinement` and `InstructionDiffView` existed but were never connected to the UI. Users had no way to request instruction improvements.

## Solution

### Field-level (per instruction step)
- Each instruction textarea now has a **✨** sparkle button that fires `refineSingle` for that one step
- When a refinement is pending, `InstructionDiffView` renders below the textarea with word-diff highlighting and Accept / Reject actions

### Section-level (all instructions)
- A **Refine all ✨** button in the Instructions section header fires `refineAll`

### Architecture
- `RecipeFormSteps` gains optional refinement props (all optional → backward-compatible)
- `RecipeFormLayout` owns the `useInstructionRefinement` hook instance and wires it through

## Tests
New `RecipeFormSteps.test.tsx` (9 tests) covering:
- Refine-all button present/absent based on handler availability
- Per-step sparkle buttons render for each instruction
- Clicking per-step button calls handler with correct index + text
- `InstructionDiffView` shown for pending refinements, hidden for accepted/rejected
- Accept / Reject callbacks fire with correct index

`CreateRecipe.test.tsx`: Updated step-3 button selectors from `/Instructions/i` → `/Go to step 3: Instructions/i` to avoid ambiguity with the new `aria-label`.

## Closes
Closes theandiman/recipe-management#37