### PR TITLE
feat(ai): show before/after comparison in AI suggestion panel

### DIFF
--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -10,7 +10,7 @@ interface AISuggestionPanelProps {
   onDismiss: (field: string) => void
   /** Maps field names to their corresponding form setter functions */
   fieldSetters: Partial<Record<string, (value: string) => void>>
-  /** Current form values keyed by field name — used to record "before" state for the audit trail */
+  /** Current form values keyed by field name — used to record "before" state for the audit trail and to show before/after comparison */
   currentValues?: Partial<Record<string, string>>
   onRetry?: () => void
 }
@@ -18,8 +18,10 @@ interface AISuggestionPanelProps {
 /**
  * Collapsible panel that displays AI-generated field suggestions.
  *
- * - Shows suggestions only for fields the user hasn't yet filled.
+ * - Renders all suggestions passed in via the `suggestions` prop.
  * - Each suggestion has an Apply and Dismiss button.
+ * - Shows the current field value alongside the suggestion for before/after
+ *   comparison when `currentValues` is provided.
  * - Visually distinguished with amber styling and ✨ icon.
  * - If the AI call fails the panel shows an error/retry state but does NOT
  *   block form submission.
@@ -104,7 +106,8 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
               {suggestions.map(suggestion => {
                 const setter = fieldSetters[suggestion.field]
                 const label = FIELD_LABELS[suggestion.field] ?? suggestion.field
-                // For audit trail: require previousValue for apply
+                const currentValue = currentValues?.[suggestion.field]
+                const previousValue = currentValue ?? ''
                 return (
                   <li
                     key={suggestion.field}
@@ -113,7 +116,15 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                     aria-label={`AI suggestion for ${label}`}
                   >
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs font-semibold text-amber-700 mb-0.5">{label}</p>
+                      <p className="text-xs font-semibold text-amber-700 mb-1">{label}</p>
+                      {currentValue && (
+                        <p
+                          className="text-xs text-gray-500 break-words bg-gray-50 rounded px-2 py-1 border border-gray-100 mb-1 line-through"
+                          aria-label={`Current value: ${currentValue}`}
+                        >
+                          {currentValue}
+                        </p>
+                      )}
                       <p
                         className="text-sm text-gray-800 break-words bg-amber-50 rounded px-2 py-1 border border-amber-100"
                         aria-label={`Suggested value: ${suggestion.suggestedValue}`}
@@ -128,10 +139,8 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                       {setter && (
                         <button
                           type="button"
-                          onClick={() => {
-                            const previousValue = currentValues?.[suggestion.field] ?? ''
-                            onApply(suggestion.field, setter, previousValue)
-                          }}
+<<<<<<< HEAD
+                          onClick={() => onApply(suggestion.field, setter, previousValue)}
                           className="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-500 hover:bg-amber-600 text-white transition-colors"
                           aria-label={`Apply AI suggestion for ${label}`}
                         >

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -139,7 +139,6 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                       {setter && (
                         <button
                           type="button"
-<<<<<<< HEAD
                           onClick={() => onApply(suggestion.field, setter, previousValue)}
                           className="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-500 hover:bg-amber-600 text-white transition-colors"
                           aria-label={`Apply AI suggestion for ${label}`}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -358,6 +358,13 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
           onApply={applySuggestion}
           onDismiss={dismissSuggestion}
           fieldSetters={fieldSetters}
+          currentValues={{
+            recipeName: title,
+            description,
+            prepTime,
+            cookTime,
+            servings,
+          }}
           onRetry={handleRetrySuggestions}
         />
       )}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -281,12 +281,12 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   }, [title])
 
   // Wrap setters to allow passing previousValue for audit trail
-  const fieldSetters: Partial<Record<string, (value: string) => void> & { currentValue?: string }> = {
-    recipeName: Object.assign(setTitle, { currentValue: title }),
-    description: Object.assign(setDescription, { currentValue: description }),
-    prepTime: Object.assign(setPrepTime, { currentValue: prepTime }),
-    cookTime: Object.assign(setCookTime, { currentValue: cookTime }),
-    servings: Object.assign(setServings, { currentValue: servings }),
+  const fieldSetters: Partial<Record<string, (value: string) => void>> = {
+    recipeName: setTitle,
+    description: setDescription,
+    prepTime: setPrepTime,
+    cookTime: setCookTime,
+    servings: setServings,
   }
 
   // Internal undo handler: uses the local audit trail (from RecipeFormLayout's own hook)
@@ -364,6 +364,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
             prepTime,
             cookTime,
             servings,
+            tags: tags.join(', '),
           }}
           onRetry={handleRetrySuggestions}
         />

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -205,3 +205,70 @@ describe('AISuggestionPanel', () => {
     expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument()
   })
 })
+
+// ─── Before/After comparison (issue #38) ─────────────────────────────────────
+
+describe('Before/after comparison', () => {
+  it('shows current value when currentValues prop is provided', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={[mockSuggestions[0]]}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{ description: vi.fn() }}
+        currentValues={{ description: 'Old description text' }}
+      />
+    )
+    expect(screen.getByLabelText(/Current value: Old description text/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Suggested value: A delicious pasta dish/i)).toBeInTheDocument()
+  })
+
+  it('does NOT show current value row when currentValues is absent', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={[mockSuggestions[0]]}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{ description: vi.fn() }}
+      />
+    )
+    expect(screen.queryByLabelText(/Current value:/i)).not.toBeInTheDocument()
+  })
+
+  it('does NOT show current value row when value for that field is empty string', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={[mockSuggestions[0]]}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{ description: vi.fn() }}
+        currentValues={{ description: '' }}
+      />
+    )
+    expect(screen.queryByLabelText(/Current value:/i)).not.toBeInTheDocument()
+  })
+
+  it('passes current value as previousValue to onApply for audit trail', () => {
+    const setter = vi.fn()
+    const onApply = vi.fn()
+    render(
+      <AISuggestionPanel
+        suggestions={[mockSuggestions[0]]}
+        status="success"
+        error={null}
+        onApply={onApply}
+        onDismiss={vi.fn()}
+        fieldSetters={{ description: setter }}
+        currentValues={{ description: 'My current description' }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /apply ai suggestion for description/i }))
+    expect(onApply).toHaveBeenCalledWith('description', setter, 'My current description')
+  })
+})


### PR DESCRIPTION
## Summary
Add a **before/after comparison** to each suggestion card in `AISuggestionPanel` so users can see their current value alongside the AI suggestion before deciding whether to apply it.

## Problem
The suggestion panel showed only the AI-generated value. Users had to remember what was already there, making it hard to judge whether the suggestion was actually an improvement.

## Solution
- New optional **`currentValues`** prop (`Partial<Record<string, string>>`) on `AISuggestionPanel`
- When a field's current value is non-empty it renders above the suggestion with strikethrough styling, creating a clear 'before → after' visual
- The `previousValue` passed to `onApply` (used by the audit trail for undo support) now reads cleanly from `currentValues[field]` instead of the previous side-channel (`.currentValue` on the setter function)
- `RecipeFormLayout` passes current form values for `recipeName`, `description`, `prepTime`, `cookTime`, `servings`

## Undo / restore
The existing **↩ Undo AI change** button in `RecipeFormLayout` already works via `useAIAuditTrail`. With this change, `previousValue` is more reliably captured so undo restores the correct pre-AI value.

## Tests
4 new tests in `AISuggestionPanel.test.tsx` (**Before/after comparison** block):
- Current value shown when `currentValues` is provided
- No current-value row when prop is absent
- No current-value row when the value is an empty string  
- Current value forwarded as `previousValue` to `onApply` for audit trail

## Closes
Closes theandiman/recipe-management#38