### PR TITLE
feat: add fetchFieldSuggestion and fieldStatus to useAISuggestions

### DIFF
--- a/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
@@ -197,6 +197,8 @@ describe('useAISuggestions', () => {
     it('should set fieldStatus[field] to loading while fetching', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let resolvePost!: (value: any) => void
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let pending!: Promise<any>
       mockPostWithAuth.mockReturnValueOnce(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         new Promise<any>((resolve) => { resolvePost = resolve })
@@ -205,13 +207,15 @@ describe('useAISuggestions', () => {
       const { result } = renderHook(() => useAISuggestions())
 
       act(() => {
-        result.current.fetchFieldSuggestion('description', '')
+        pending = result.current.fetchFieldSuggestion('description', '')
       })
 
       expect(result.current.fieldStatus.get('description')).toBe('loading')
 
-      // Resolve to avoid unhandled promise
-      resolvePost({ data: { suggestions: [{ field: 'description', suggestedValue: 'x', reason: '' }] } })
+      await act(async () => {
+        resolvePost({ data: { suggestions: [{ field: 'description', suggestedValue: 'x', reason: '' }] } })
+        await pending
+      })
     })
 
     it('should add single-field suggestion to suggestions on success', async () => {

--- a/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
@@ -193,6 +193,162 @@ describe('useAISuggestions', () => {
     window.removeEventListener('ai:suggestions', listener)
   })
 
+  describe('fetchFieldSuggestion', () => {
+    it('should set fieldStatus[field] to loading while fetching', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let resolvePost!: (value: any) => void
+      mockPostWithAuth.mockReturnValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        new Promise<any>((resolve) => { resolvePost = resolve })
+      )
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      act(() => {
+        result.current.fetchFieldSuggestion('description', '')
+      })
+
+      expect(result.current.fieldStatus.get('description')).toBe('loading')
+
+      // Resolve to avoid unhandled promise
+      resolvePost({ data: { suggestions: [{ field: 'description', suggestedValue: 'x', reason: '' }] } })
+    })
+
+    it('should add single-field suggestion to suggestions on success', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'A delicious meal', reason: 'No description' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      expect(result.current.suggestions).toHaveLength(1)
+      expect(result.current.suggestions[0].field).toBe('description')
+      expect(result.current.suggestions[0].suggestedValue).toBe('A delicious meal')
+    })
+
+    it('should set fieldStatus[field] to success after fetch', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'prepTime', suggestedValue: '15 minutes', reason: '' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('prepTime', '')
+      })
+
+      expect(result.current.fieldStatus.get('prepTime')).toBe('success')
+    })
+
+    it('should set fieldStatus[field] to error if fetch fails', async () => {
+      mockPostWithAuth.mockRejectedValueOnce(new Error('API error'))
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('cookTime', '')
+      })
+
+      expect(result.current.fieldStatus.get('cookTime')).toBe('error')
+    })
+
+    it('should not affect fieldStatus or suggestions for other fields', async () => {
+      // Pre-populate suggestions for another field via fetchSuggestions
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'prepTime', suggestedValue: '10 min', reason: '' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Pasta' })
+      })
+
+      // Now fetch for a different field
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Tasty', reason: '' }],
+        },
+      } as any)
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      // prepTime suggestion should still be present
+      const prepTimeSuggestion = result.current.suggestions.find(s => s.field === 'prepTime')
+      expect(prepTimeSuggestion).toBeDefined()
+      expect(prepTimeSuggestion?.suggestedValue).toBe('10 min')
+
+      // fieldStatus for description should be success, prepTime unaffected
+      expect(result.current.fieldStatus.get('description')).toBe('success')
+      expect(result.current.fieldStatus.get('prepTime')).toBeUndefined()
+    })
+
+    it('should pass currentValue in the targeted request to the API', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: { suggestions: [] },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', 'partial desc', { recipeName: 'Test Recipe' })
+      })
+
+      expect(mockPostWithAuth).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ description: 'partial desc', recipeName: 'Test Recipe' })
+      )
+    })
+
+    it('should not reset existing suggestions for other fields', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [
+            { field: 'prepTime', suggestedValue: '10 min', reason: '' },
+            { field: 'cookTime', suggestedValue: '20 min', reason: '' },
+          ],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Pasta' })
+      })
+
+      expect(result.current.suggestions).toHaveLength(2)
+
+      // Fetch only for description
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'A tasty dish', reason: '' }],
+        },
+      } as any)
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      // All three fields should be present
+      expect(result.current.suggestions).toHaveLength(3)
+      expect(result.current.suggestions.map(s => s.field)).toContain('prepTime')
+      expect(result.current.suggestions.map(s => s.field)).toContain('cookTime')
+      expect(result.current.suggestions.map(s => s.field)).toContain('description')
+    })
+  })
+
   describe('API base URL resolution', () => {
     it('uses VITE_AI_API_URL when set, preferring it over VITE_API_URL', async () => {
       vi.stubEnv('VITE_AI_API_URL', 'https://ai.example.com')

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -33,6 +33,8 @@ interface UseAISuggestionsReturn {
   status: SuggestionStatus
   error: string | null
   fetchSuggestions: (request: FieldSuggestionRequest) => Promise<void>
+  fetchFieldSuggestion: (field: keyof FieldSuggestionRequest, currentValue: string, context?: Partial<FieldSuggestionRequest>) => Promise<void>
+  fieldStatus: Map<string, SuggestionStatus>
   applySuggestion: (field: string, applyFn: (value: string) => void, previousValue: string) => void
   dismissSuggestion: (field: string) => void
   visibleSuggestions: FieldSuggestion[]
@@ -55,6 +57,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
   const [dismissedFields, setDismissedFields] = useState<Set<string>>(new Set())
   const [status, setStatus] = useState<SuggestionStatus>('idle')
   const [error, setError] = useState<string | null>(null)
+  const [fieldStatus, setFieldStatus] = useState<Map<string, SuggestionStatus>>(new Map())
 
   const {
     auditLog,
@@ -100,6 +103,38 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     }
   }, [recordSuggestion])
 
+  const fetchFieldSuggestion = useCallback(async (
+    field: keyof FieldSuggestionRequest,
+    currentValue: string,
+    context?: Partial<FieldSuggestionRequest>
+  ) => {
+    setFieldStatus(prev => new Map(prev).set(field, 'loading'))
+
+    const request: FieldSuggestionRequest = { ...context, [field]: currentValue }
+
+    try {
+      const apiBase = import.meta.env.VITE_AI_API_URL ?? import.meta.env.VITE_API_URL ?? ''
+      const url = buildApiUrl(apiBase, '/api/recipes/suggest-fields')
+      const res = await postWithAuth(url, request)
+      const data = res.data as { suggestions: FieldSuggestion[] }
+      const fetched = data?.suggestions ?? []
+
+      setSuggestions(prev => {
+        const withoutField = prev.filter(s => s.field !== field)
+        return [...withoutField, ...fetched.filter(s => s.field === field)]
+      })
+      setFieldStatus(prev => new Map(prev).set(field, 'success'))
+
+      for (const s of fetched) {
+        recordSuggestion(s.field, s.suggestedValue)
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to fetch AI suggestion'
+      setFieldStatus(prev => new Map(prev).set(field, 'error'))
+      console.warn('[AI Suggestions] fetchFieldSuggestion failed:', msg)
+    }
+  }, [recordSuggestion])
+
   const applySuggestion = useCallback((field: string, applyFn: (value: string) => void, previousValue: string) => {
     const suggestion = suggestions.find(s => s.field === field)
     if (!suggestion) return
@@ -132,6 +167,8 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     status,
     error,
     fetchSuggestions,
+    fetchFieldSuggestion,
+    fieldStatus,
     applySuggestion,
     dismissSuggestion,
     visibleSuggestions,

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -27,13 +27,16 @@ export interface FieldSuggestionRequest {
 
 export type SuggestionStatus = 'idle' | 'loading' | 'success' | 'error'
 
+/** String-valued keys of FieldSuggestionRequest (excludes array-typed fields like tags/ingredients/instructions). */
+export type StringFieldKey = Exclude<keyof FieldSuggestionRequest, 'tags' | 'ingredients' | 'instructions'>
+
 interface UseAISuggestionsReturn {
   suggestions: FieldSuggestion[]
   dismissedFields: Set<string>
   status: SuggestionStatus
   error: string | null
   fetchSuggestions: (request: FieldSuggestionRequest) => Promise<void>
-  fetchFieldSuggestion: (field: keyof FieldSuggestionRequest, currentValue: string, context?: Partial<FieldSuggestionRequest>) => Promise<void>
+  fetchFieldSuggestion: (field: StringFieldKey, currentValue: string, context?: Partial<FieldSuggestionRequest>) => Promise<void>
   fieldStatus: Map<string, SuggestionStatus>
   applySuggestion: (field: string, applyFn: (value: string) => void, previousValue: string) => void
   dismissSuggestion: (field: string) => void
@@ -72,6 +75,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
   const fetchSuggestions = useCallback(async (request: FieldSuggestionRequest) => {
     setSuggestions([])
     setDismissedFields(new Set())
+    setFieldStatus(new Map())
     setStatus('loading')
     setError(null)
     const startTime = Date.now()
@@ -104,11 +108,12 @@ export function useAISuggestions(): UseAISuggestionsReturn {
   }, [recordSuggestion])
 
   const fetchFieldSuggestion = useCallback(async (
-    field: keyof FieldSuggestionRequest,
+    field: StringFieldKey,
     currentValue: string,
     context?: Partial<FieldSuggestionRequest>
   ) => {
     setFieldStatus(prev => new Map(prev).set(field, 'loading'))
+    setError(null)
 
     const request: FieldSuggestionRequest = { ...context, [field]: currentValue }
 
@@ -118,18 +123,25 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       const res = await postWithAuth(url, request)
       const data = res.data as { suggestions: FieldSuggestion[] }
       const fetched = data?.suggestions ?? []
+      const fieldSuggestions = fetched.filter(s => s.field === field)
 
       setSuggestions(prev => {
         const withoutField = prev.filter(s => s.field !== field)
-        return [...withoutField, ...fetched.filter(s => s.field === field)]
+        return [...withoutField, ...fieldSuggestions]
+      })
+      setDismissedFields(prev => {
+        const next = new Set(prev)
+        next.delete(field)
+        return next
       })
       setFieldStatus(prev => new Map(prev).set(field, 'success'))
 
-      for (const s of fetched) {
+      for (const s of fieldSuggestions) {
         recordSuggestion(s.field, s.suggestedValue)
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to fetch AI suggestion'
+      setError(msg)
       setFieldStatus(prev => new Map(prev).set(field, 'error'))
       console.warn('[AI Suggestions] fetchFieldSuggestion failed:', msg)
     }


### PR DESCRIPTION
## Summary
Extends `useAISuggestions` with per-field AI request capability:
- `fetchFieldSuggestion(field, currentValue, context?)` — sends a targeted suggest-fields request for one field
- `fieldStatus: Map<string, SuggestionStatus>` — per-field loading/success/error tracking
- New suggestion merged non-destructively into existing `suggestions` array
- Bulk `fetchSuggestions()` unchanged

## Closes
Closes theandiman/recipe-management#39

## Testing
BDD tests added to `useAISuggestions.test.ts` covering all new behaviour.