### PR TITLE
feat: add AI image generation to recipe image upload

### DIFF
--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -7,6 +7,7 @@ import { RecipePreview } from './RecipePreview'
 import { AISuggestionPanel } from './AISuggestionPanel'
 import { useAISuggestions } from '../hooks/useAISuggestions'
 import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
+import { useAIImageGeneration } from '../hooks/useAIImageGeneration'
 import { FIELD_LABELS } from '../constants/aiConstants'
 import { useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
@@ -41,6 +42,7 @@ interface RecipeFormLayoutProps {
   imagePreview: string | null
   handleImageUpload: (e: React.ChangeEvent<HTMLInputElement>) => void
   removeImage: () => void
+  setImagePreview?: (value: string | null) => void
   ingredients: Ingredient[]
   addIngredient: () => void
   updateIngredient: (index: number, field: keyof Ingredient, value: string) => void
@@ -106,6 +108,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   imagePreview,
   handleImageUpload,
   removeImage,
+  setImagePreview,
   ingredients,
   addIngredient,
   updateIngredient,
@@ -149,6 +152,17 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     acceptStep: acceptInstructionRefinement,
     rejectStep: rejectInstructionRefinement,
   } = useInstructionRefinement(updateInstruction)
+
+  // --- AI Image Generation Hook ---
+  const { status: aiImageStatus, error: aiImageError, generateImage } = useAIImageGeneration()
+
+  const handleGenerateAIImage = useCallback(
+    async (recipeName: string, description?: string) => {
+      const url = await generateImage(recipeName, description)
+      if (url && setImagePreview) setImagePreview(url)
+    },
+    [generateImage, setImagePreview]
+  )
 
   const handleRefineInstruction = useCallback(
     (index: number, instruction: string) => {
@@ -474,6 +488,9 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 fieldSuggestions={visibleSuggestions}
                 onApplyFieldSuggestion={handleApplyFieldSuggestion}
                 onDismissFieldSuggestion={dismissSuggestion}
+                onGenerateAIImage={setImagePreview ? handleGenerateAIImage : undefined}
+                generatingAIImage={aiImageStatus === 'loading'}
+                aiImageError={aiImageError}
               />
           </div>
 

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -67,6 +67,10 @@ interface RecipeFormStepsProps {
   fieldSuggestions?: FieldSuggestion[]
   onApplyFieldSuggestion?: (field: string, value: string) => void
   onDismissFieldSuggestion?: (field: string) => void
+  // AI Image Generation
+  onGenerateAIImage?: (recipeName: string, description?: string) => Promise<void>
+  generatingAIImage?: boolean
+  aiImageError?: string | null
 }
 
 
@@ -106,6 +110,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
   removeDietaryRestriction,
   fieldErrors,
   clearFieldError,
+  recipeName,
   onRefineInstruction,
   onRefineAllInstructions,
   instructionRefinementStates,
@@ -120,6 +125,9 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
   fieldSuggestions,
   onApplyFieldSuggestion,
   onDismissFieldSuggestion,
+  onGenerateAIImage,
+  generatingAIImage = false,
+  aiImageError,
 }) => {
   const getFieldStatus = (field: string): SuggestionStatus =>
     fieldStatus?.get(field) ?? 'idle'
@@ -273,6 +281,34 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   </svg>
                 </button>
               </div>
+            )}
+
+            {onGenerateAIImage && (
+              <>
+                <button
+                  type="button"
+                  onClick={() => onGenerateAIImage(recipeName.trim(), description || undefined)}
+                  disabled={!recipeName.trim() || generatingAIImage}
+                  className="mt-3 flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {generatingAIImage ? (
+                    <>
+                      <span className="animate-spin" aria-hidden="true">⏳</span>
+                      Generating...
+                    </>
+                  ) : (
+                    <>
+                      <span aria-hidden="true">✨</span>
+                      {imagePreview ? 'Regenerate image' : 'Generate image'}
+                    </>
+                  )}
+                </button>
+                {aiImageError && (
+                  <p className="mt-2 text-xs text-red-600 flex items-center gap-1">
+                    <span aria-hidden="true">⚠️</span> {aiImageError}
+                  </p>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -232,3 +232,76 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
     expect(onDismiss).toHaveBeenCalledWith('recipeName')
   })
 })
+
+describe('RecipeFormSteps — AI image generation (issue #41)', () => {
+  function makeStep1Props(overrides: Partial<ComponentProps<typeof RecipeFormSteps>> = {}) {
+    return makeProps({ currentStep: 1, ...overrides })
+  }
+
+  it('shows "Generate image" button when onGenerateAIImage prop provided and imagePreview is null', () => {
+    render(<RecipeFormSteps {...makeStep1Props({ onGenerateAIImage: vi.fn() })} />)
+    expect(screen.getByRole('button', { name: /Generate image/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Generate image/i })).toHaveTextContent('Generate image')
+  })
+
+  it('does NOT show AI generate button when onGenerateAIImage prop is absent', () => {
+    render(<RecipeFormSteps {...makeStep1Props()} />)
+    expect(screen.queryByRole('button', { name: /Generate image/i })).not.toBeInTheDocument()
+  })
+
+  it('shows "Regenerate image" button when imagePreview is set', () => {
+    render(
+      <RecipeFormSteps
+        {...makeStep1Props({
+          onGenerateAIImage: vi.fn(),
+          imagePreview: 'https://example.com/image.jpg',
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: /Regenerate image/i })).toBeInTheDocument()
+  })
+
+  it('disables button when recipeName is empty', () => {
+    render(
+      <RecipeFormSteps
+        {...makeStep1Props({
+          onGenerateAIImage: vi.fn(),
+          title: '',
+          recipeName: '',
+        })}
+      />
+    )
+    expect(screen.getByRole('button', { name: /Generate image/i })).toBeDisabled()
+  })
+
+  it('shows loading state when generatingAIImage is true', () => {
+    render(
+      <RecipeFormSteps
+        {...makeStep1Props({
+          onGenerateAIImage: vi.fn(),
+          generatingAIImage: true,
+        })}
+      />
+    )
+    const btn = screen.getByRole('button', { name: /Generating/i })
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveTextContent('Generating...')
+  })
+
+  it('calls onGenerateAIImage with recipeName and description when clicked', () => {
+    const onGenerate = vi.fn()
+    render(
+      <RecipeFormSteps
+        {...makeStep1Props({
+          onGenerateAIImage: onGenerate,
+          title: 'Pasta',
+          recipeName: 'Pasta',
+          description: 'Delicious pasta',
+        })}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Generate image/i }))
+    expect(onGenerate).toHaveBeenCalledWith('Pasta', 'Delicious pasta')
+
+  })
+})

--- a/src/features/recipes/hooks/__tests__/useAIImageGeneration.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAIImageGeneration.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAIImageGeneration } from '../useAIImageGeneration'
+
+vi.mock('../../../../utils/authApi', () => ({
+  postWithAuth: vi.fn(),
+}))
+vi.mock('../../../../utils/apiUtils', () => ({
+  buildApiUrl: (_base: string, endpoint: string) => endpoint,
+}))
+
+import { postWithAuth } from '../../../../utils/authApi'
+
+const mockPost = postWithAuth as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useAIImageGeneration', () => {
+  it('should return status idle initially', () => {
+    const { result } = renderHook(() => useAIImageGeneration())
+    expect(result.current.status).toBe('idle')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('should set status loading while generating', async () => {
+    let resolvePost!: (value: unknown) => void
+    mockPost.mockReturnValueOnce(new Promise((r) => { resolvePost = r }))
+
+    const { result } = renderHook(() => useAIImageGeneration())
+
+    act(() => {
+      result.current.generateImage('Test Recipe')
+    })
+
+    expect(result.current.status).toBe('loading')
+
+    await act(async () => {
+      resolvePost({ data: { imageUrl: 'https://example.com/image.jpg' } })
+    })
+  })
+
+  it('should return imageUrl on success and set status success', async () => {
+    mockPost.mockResolvedValueOnce({ data: { imageUrl: 'https://example.com/image.jpg' } })
+
+    const { result } = renderHook(() => useAIImageGeneration())
+
+    let url: string | null = null
+    await act(async () => {
+      url = await result.current.generateImage('Test Recipe', 'A tasty dish')
+    })
+
+    expect(url).toBe('https://example.com/image.jpg')
+    expect(result.current.status).toBe('success')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('should set status error and error message on failure', async () => {
+    mockPost.mockRejectedValueOnce(new Error('Network error'))
+
+    const { result } = renderHook(() => useAIImageGeneration())
+
+    let url: string | null = null
+    await act(async () => {
+      url = await result.current.generateImage('Test Recipe')
+    })
+
+    expect(url).toBeNull()
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toBe('Network error')
+  })
+
+  it('should set status error when response contains no usable imageUrl', async () => {
+    mockPost.mockResolvedValueOnce({ data: {} })
+
+    const { result } = renderHook(() => useAIImageGeneration())
+
+    let url: string | null = null
+    await act(async () => {
+      url = await result.current.generateImage('Test Recipe')
+    })
+
+    expect(url).toBeNull()
+    expect(result.current.status).toBe('error')
+    expect(result.current.error).toMatch(/usable image URL/i)
+  })
+
+  it('should reset error on new generation attempt', async () => {
+    mockPost.mockRejectedValueOnce(new Error('First error'))
+    mockPost.mockResolvedValueOnce({ data: { imageUrl: 'https://example.com/image2.jpg' } })
+
+    const { result } = renderHook(() => useAIImageGeneration())
+
+    await act(async () => {
+      await result.current.generateImage('Test Recipe')
+    })
+    expect(result.current.error).toBe('First error')
+
+    await act(async () => {
+      await result.current.generateImage('Test Recipe')
+    })
+    expect(result.current.error).toBeNull()
+    expect(result.current.status).toBe('success')
+  })
+})

--- a/src/features/recipes/hooks/useAIImageGeneration.ts
+++ b/src/features/recipes/hooks/useAIImageGeneration.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from 'react'
+import { buildApiUrl } from '../../../utils/apiUtils'
+import { postWithAuth } from '../../../utils/authApi'
+
+export type AIImageGenerationStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface UseAIImageGenerationReturn {
+  status: AIImageGenerationStatus
+  error: string | null
+  generateImage: (recipeName: string, description?: string) => Promise<string | null>
+}
+
+/**
+ * Manages AI image generation state and API calls.
+ *
+ * BDD Scenarios covered:
+ *   - Returns 'idle' status initially
+ *   - Sets 'loading' while generating
+ *   - Returns imageUrl and sets 'success' on successful generation
+ *   - Sets 'error' status and message on failure
+ *   - Resets error on new generation attempt
+ */
+export function useAIImageGeneration(): UseAIImageGenerationReturn {
+  const [status, setStatus] = useState<AIImageGenerationStatus>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  const generateImage = useCallback(
+    async (recipeName: string, description?: string): Promise<string | null> => {
+      setStatus('loading')
+      setError(null)
+      try {
+        const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
+        const url = buildApiUrl(apiBase, '/api/recipes/image/generate')
+        const res = await postWithAuth(url, { recipeName, description })
+        const data = res.data as { imageUrl?: string; image?: string }
+        const imageUrl = data?.imageUrl || data?.image || null
+
+        if (typeof imageUrl !== 'string' || imageUrl.trim() === '') {
+          const msg = 'Image generation did not return a usable image URL'
+          setError(msg)
+          setStatus('error')
+          console.warn('[AIImageGeneration] generateImage failed:', msg)
+          return null
+        }
+
+        setStatus('success')
+        return imageUrl
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Image generation unavailable'
+        setError(msg)
+        setStatus('error')
+        console.warn('[AIImageGeneration] generateImage failed:', msg)
+        return null
+      }
+    },
+    []
+  )
+
+  return { status, error, generateImage }
+}


### PR DESCRIPTION
## Summary
Adds AI image generation capability to the recipe image upload section:

- **`useAIImageGeneration` hook** — manages loading/success/error for POST `/api/recipes/image/generate`
- **✨ Generate image button** in Step 1 image upload zone
- Smart labeling: shows 'Regenerate image' when image already set
- Disabled when recipe name is empty (needs context to generate)
- Loading spinner + disabled state during generation
- Generated image set as `imagePreview`

## Closes
Closes theandiman/recipe-management#41

## Testing
New hook tests in `useAIImageGeneration.test.ts`
Component integration tests in `RecipeFormSteps.test.tsx`