### PR TITLE
feat: surface AI undo affordance after applying suggestions

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -295,7 +295,7 @@ describe('AI Undo Affordance', () => {
           { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
         ],
       },
-    })
+    } as any)
 
     renderWithRouter(<SimpleCreateRecipe />)
     fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
@@ -323,7 +323,7 @@ describe('AI Undo Affordance', () => {
           { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
         ],
       },
-    })
+    } as any)
 
     renderWithRouter(<SimpleCreateRecipe />)
     fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { SimpleCreateRecipe } from './SimpleCreateRecipe'
 
@@ -265,6 +265,86 @@ describe('AI Enhancement', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
+    })
+  })
+})
+
+// ─── AI Undo Affordance (issue #42) ──────────────────────────────────────────
+
+describe('AI Undo Affordance', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not show undo button before any AI suggestion is applied', () => {
+    renderWithRouter(<SimpleCreateRecipe />)
+    expect(screen.queryByRole('button', { name: /Undo:/i })).not.toBeInTheDocument()
+  })
+
+  it('shows undo button after accepting an AI suggestion', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
+        ],
+      },
+    })
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    // Wait for the suggestion panel, then click its Apply button
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
+    })
+    const panel = screen.getByRole('region', { name: /AI field suggestions/i })
+    await waitFor(() => {
+      expect(within(panel).getByRole('button', { name: /Apply AI suggestion/i })).toBeInTheDocument()
+    })
+    fireEvent.click(within(panel).getByRole('button', { name: /Apply AI suggestion/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
+    })
+  })
+
+  it('hides undo button after it is clicked (undo reverts field)', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
+        ],
+      },
+    })
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
+    })
+    const panel = screen.getByRole('region', { name: /AI field suggestions/i })
+    await waitFor(() => {
+      expect(within(panel).getByRole('button', { name: /Apply AI suggestion/i })).toBeInTheDocument()
+    })
+    fireEvent.click(within(panel).getByRole('button', { name: /Apply AI suggestion/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Undo: Description/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Undo: Description/i })).not.toBeInTheDocument()
     })
   })
 })

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -111,11 +111,8 @@ export const SimpleCreateRecipe: React.FC = () => {
   }
 
   const lastUndoableAIField = useMemo<string | null>(() => {
-    for (let i = auditLog.length - 1; i >= 0; i--) {
-      const e = auditLog[i]
-      if (e.event === 'accepted') return e.field
-    }
-    return null
+    const latestEntry = auditLog[auditLog.length - 1]
+    return latestEntry?.event === 'accepted' ? latestEntry.field : null
   }, [auditLog])
 
   const handleUndo = useCallback(() => {
@@ -133,6 +130,7 @@ export const SimpleCreateRecipe: React.FC = () => {
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Create Recipe</h1>
           <div className="flex items-center gap-2">
             <AIUndoButton
+              key={auditLog.length}
               lastField={canUndo ? lastUndoableAIField : null}
               onUndo={handleUndo}
               fieldLabels={FIELD_LABELS}

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -13,6 +13,8 @@ import type { StringFieldKey } from './hooks/useAISuggestions'
 import { AISuggestionPanel } from './components/AISuggestionPanel'
 import { FieldAIEnhanceButton } from './components/FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './components/FieldAISuggestionChip'
+import { AIUndoButton } from './components/AIUndoButton'
+import { FIELD_LABELS } from './constants/aiConstants'
 
 export const SimpleCreateRecipe: React.FC = () => {
   const navigate = useNavigate()
@@ -55,6 +57,9 @@ export const SimpleCreateRecipe: React.FC = () => {
     fieldStatus,
     applySuggestion,
     dismissSuggestion,
+    canUndo,
+    undoLastAIChange,
+    auditLog,
   } = useAISuggestions()
 
   const buildSuggestionRequest = () => ({
@@ -105,26 +110,48 @@ export const SimpleCreateRecipe: React.FC = () => {
     fetchSuggestions(buildSuggestionRequest())
   }
 
+  const lastUndoableAIField = useMemo<string | null>(() => {
+    for (let i = auditLog.length - 1; i >= 0; i--) {
+      const e = auditLog[i]
+      if (e.event === 'accepted') return e.field
+    }
+    return null
+  }, [auditLog])
+
+  const handleUndo = useCallback(() => {
+    const result = undoLastAIChange()
+    if (!result) return
+    const setter = fieldSetters[result.field]
+    if (setter) setter(String(result.previousValue ?? ''))
+  }, [undoLastAIChange, fieldSetters])
+
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
       {/* Header */}
       <div className="mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Create Recipe</h1>
-          <button
-            type="button"
-            onClick={handleEnhanceWithAI}
-            disabled={suggestionStatus === 'loading'}
-            aria-label="Enhance recipe with AI"
-            className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {suggestionStatus === 'loading' ? (
-              <span className="animate-spin">⏳</span>
-            ) : (
-              <span aria-hidden="true">✨</span>
-            )}
-            Enhance with AI
-          </button>
+          <div className="flex items-center gap-2">
+            <AIUndoButton
+              lastField={canUndo ? lastUndoableAIField : null}
+              onUndo={handleUndo}
+              fieldLabels={FIELD_LABELS}
+            />
+            <button
+              type="button"
+              onClick={handleEnhanceWithAI}
+              disabled={suggestionStatus === 'loading'}
+              aria-label="Enhance recipe with AI"
+              className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {suggestionStatus === 'loading' ? (
+                <span className="animate-spin">⏳</span>
+              ) : (
+                <span aria-hidden="true">✨</span>
+              )}
+              Enhance with AI
+            </button>
+          </div>
         </div>
 
         {/* Entry-point mode toggle */}

--- a/src/features/recipes/components/AIUndoButton.tsx
+++ b/src/features/recipes/components/AIUndoButton.tsx
@@ -31,7 +31,7 @@ export const AIUndoButton: React.FC<AIUndoButtonProps> = ({ lastField, onUndo, f
       aria-label={`Undo: ${label}`}
       className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 transition-colors"
     >
-      ↩ Undo: {label}
+      <span aria-hidden="true">↩</span> Undo: {label}
     </button>
   )
 }

--- a/src/features/recipes/components/AIUndoButton.tsx
+++ b/src/features/recipes/components/AIUndoButton.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react'
+
+interface AIUndoButtonProps {
+  lastField: string | null
+  onUndo: () => void
+  fieldLabels: Record<string, string>
+}
+
+/**
+ * Subtle undo affordance shown after an AI suggestion is applied.
+ * Auto-dismisses after 8 seconds; timer resets whenever lastField changes.
+ */
+export const AIUndoButton: React.FC<AIUndoButtonProps> = ({ lastField, onUndo, fieldLabels }) => {
+  const [visible, setVisible] = useState(true)
+
+  useEffect(() => {
+    if (!lastField) return
+    setVisible(true)
+    const timer = setTimeout(() => setVisible(false), 8000)
+    return () => clearTimeout(timer)
+  }, [lastField])
+
+  if (!lastField || !visible) return null
+
+  const label = fieldLabels[lastField] ?? lastField
+
+  return (
+    <button
+      type="button"
+      onClick={onUndo}
+      aria-label={`Undo: ${label}`}
+      className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 transition-colors"
+    >
+      ↩ Undo: {label}
+    </button>
+  )
+}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -9,6 +9,7 @@ import { useAISuggestions } from '../hooks/useAISuggestions'
 import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
 import { useAIImageGeneration } from '../hooks/useAIImageGeneration'
 import { FIELD_LABELS } from '../constants/aiConstants'
+import { AIUndoButton } from './AIUndoButton'
 import { useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
 import type { Ingredient } from '../../../types/nutrition'
@@ -136,9 +137,9 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   setSaveError,
   handleSubmit,
   handleCancel,
-  canUndoAI: _canUndoAI = false,
+  canUndoAI = false,
   onUndoLastAI,
-  lastUndoableAIField: _lastUndoableAIField,
+  lastUndoableAIField,
   normalizationStates,
   onApplyNormalization,
   onDismissNormalization,
@@ -275,12 +276,12 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     auditLog: localAuditLog,
   } = useAISuggestions()
 
-  // Derive the last undoable AI field name from the local audit trail
+  // Derive the last undoable AI field key from the local audit trail
   const localLastUndoableAIField = useMemo<string | null>(() => {
     for (let i = localAuditLog.length - 1; i >= 0; i--) {
       const e = localAuditLog[i]
       if (e.event === 'accepted') {
-        return FIELD_LABELS[e.field] ?? e.field
+        return e.field
       }
     }
     return null
@@ -369,20 +370,27 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
             </p>
           </div>
           {currentStep !== 5 && (
-            <button
-              type="button"
-              onClick={handleEnhanceWithAI}
-              disabled={suggestionStatus === 'loading'}
-              aria-label="Enhance recipe with AI"
-              className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {suggestionStatus === 'loading' ? (
-                <span className="animate-spin">⏳</span>
-              ) : (
-                <span aria-hidden="true">✨</span>
-              )}
-              Enhance with AI
-            </button>
+            <div className="flex items-center gap-2">
+              <AIUndoButton
+                lastField={localCanUndo ? localLastUndoableAIField : null}
+                onUndo={handleLocalUndo}
+                fieldLabels={FIELD_LABELS}
+              />
+              <button
+                type="button"
+                onClick={handleEnhanceWithAI}
+                disabled={suggestionStatus === 'loading'}
+                aria-label="Enhance recipe with AI"
+                className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {suggestionStatus === 'loading' ? (
+                  <span className="animate-spin">⏳</span>
+                ) : (
+                  <span aria-hidden="true">✨</span>
+                )}
+                Enhance with AI
+              </button>
+            </div>
           )}
         </div>
 
@@ -533,17 +541,6 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
             </button>
 
             <div className="flex items-center space-x-4">
-              {localCanUndo && (
-                <button
-                  type="button"
-                  onClick={handleLocalUndo}
-                  aria-label={localLastUndoableAIField ? `Undo AI change to ${localLastUndoableAIField}` : 'Undo last AI change'}
-                  className="px-4 py-2 text-sm border border-amber-400 text-amber-700 rounded-lg font-medium hover:bg-amber-50 transition-colors flex items-center gap-1"
-                >
-                  ↩ {localLastUndoableAIField ? `Undo AI: ${localLastUndoableAIField}` : 'Undo AI change'}
-                </button>
-              )}
-
               <button
                 type="button"
                 onClick={handleCancel}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 import { StepIndicator } from './StepIndicator'
 import { RecipeFormSteps } from './RecipeFormSteps'
+import { AISpinnerIcon } from './AISpinnerIcon'
 
 
 import { RecipePreview } from './RecipePreview'
@@ -287,6 +288,10 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     return null
   }, [localAuditLog])
 
+  // Effective undo state: prefer local audit trail; fall back to parent-supplied props
+  const effectiveCanUndo = localCanUndo || canUndoAI
+  const effectiveUndoField = localLastUndoableAIField ?? lastUndoableAIField ?? null
+
   // Wrap setters to allow passing previousValue for audit trail
   const fieldSetters: Partial<Record<string, (value: string) => void>> = useMemo(() => ({
     recipeName: setTitle,
@@ -372,7 +377,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
           {currentStep !== 5 && (
             <div className="flex items-center gap-2">
               <AIUndoButton
-                lastField={localCanUndo ? localLastUndoableAIField : null}
+                lastField={effectiveCanUndo ? effectiveUndoField : null}
                 onUndo={handleLocalUndo}
                 fieldLabels={FIELD_LABELS}
               />
@@ -384,7 +389,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {suggestionStatus === 'loading' ? (
-                  <span className="animate-spin">⏳</span>
+                  <AISpinnerIcon />
                 ) : (
                   <span aria-hidden="true">✨</span>
                 )}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -276,15 +276,12 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     auditLog: localAuditLog,
   } = useAISuggestions()
 
-  // Derive the last undoable AI field key from the local audit trail
+  // Derive the last undoable AI field from the most recent accepted entry.
+  // After an undo the latest entry may no longer be 'accepted', so returning
+  // the field only for the last entry when it is 'accepted' avoids stale labels.
   const localLastUndoableAIField = useMemo<string | null>(() => {
-    for (let i = localAuditLog.length - 1; i >= 0; i--) {
-      const e = localAuditLog[i]
-      if (e.event === 'accepted') {
-        return e.field
-      }
-    }
-    return null
+    const latestEntry = localAuditLog[localAuditLog.length - 1]
+    return latestEntry?.event === 'accepted' ? latestEntry.field : null
   }, [localAuditLog])
 
   // Effective undo state: prefer local audit trail; fall back to parent-supplied props
@@ -373,13 +370,14 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               Step {currentStep} of {totalSteps}: {steps[currentStep - 1].title}
             </p>
           </div>
-          {currentStep !== 5 && (
-            <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2">
               <AIUndoButton
+                key={localAuditLog.length}
                 lastField={effectiveCanUndo ? effectiveUndoField : null}
                 onUndo={handleLocalUndo}
                 fieldLabels={FIELD_LABELS}
               />
+              {currentStep !== 5 && (
               <button
                 type="button"
                 onClick={handleEnhanceWithAI}
@@ -394,8 +392,8 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 )}
                 Enhance with AI
               </button>
+              )}
             </div>
-          )}
         </div>
 
         {/* Step Progress Indicator - Horizontal scroll on mobile */}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 import { StepIndicator } from './StepIndicator'
 import { RecipeFormSteps } from './RecipeFormSteps'
-import { AISpinnerIcon } from './AISpinnerIcon'
 
 
 import { RecipePreview } from './RecipePreview'
@@ -389,7 +388,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {suggestionStatus === 'loading' ? (
-                  <AISpinnerIcon />
+                  <span className="animate-spin">⏳</span>
                 ) : (
                   <span aria-hidden="true">✨</span>
                 )}

--- a/src/features/recipes/components/__tests__/AIUndoButton.test.tsx
+++ b/src/features/recipes/components/__tests__/AIUndoButton.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { AIUndoButton } from '../AIUndoButton'
+import { FIELD_LABELS } from '../../constants/aiConstants'
+
+describe('AIUndoButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when lastField is null', () => {
+    const { container } = render(
+      <AIUndoButton lastField={null} onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders undo button with mapped label when lastField is set', () => {
+    render(
+      <AIUndoButton lastField="recipeName" onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+    expect(screen.getByRole('button', { name: /Undo: Recipe Name/i })).toBeInTheDocument()
+  })
+
+  it('renders undo button using raw field key as fallback when label not found', () => {
+    render(
+      <AIUndoButton lastField="unknownField" onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+    expect(screen.getByRole('button', { name: /Undo: unknownField/i })).toBeInTheDocument()
+  })
+
+  it('calls onUndo when the button is clicked', () => {
+    const onUndo = vi.fn()
+    render(
+      <AIUndoButton lastField="description" onUndo={onUndo} fieldLabels={FIELD_LABELS} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Undo: Description/i }))
+    expect(onUndo).toHaveBeenCalledOnce()
+  })
+
+  it('auto-dismisses after 8 seconds', () => {
+    render(
+      <AIUndoButton lastField="recipeName" onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+    expect(screen.getByRole('button', { name: /Undo: Recipe Name/i })).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(8000)
+    })
+
+    expect(screen.queryByRole('button', { name: /Undo: Recipe Name/i })).not.toBeInTheDocument()
+  })
+
+  it('resets the auto-dismiss timer when lastField changes', () => {
+    const { rerender } = render(
+      <AIUndoButton lastField="recipeName" onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+
+    // Advance 5 seconds — not dismissed yet
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(screen.getByRole('button', { name: /Undo: Recipe Name/i })).toBeInTheDocument()
+
+    // Change lastField — timer should reset
+    rerender(
+      <AIUndoButton lastField="description" onUndo={vi.fn()} fieldLabels={FIELD_LABELS} />
+    )
+
+    // Another 5 seconds: total 10s from start but only 5s from last change — still visible
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
+
+    // Another 3 seconds — now 8s from last change — dismissed
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(screen.queryByRole('button', { name: /Undo: Description/i })).not.toBeInTheDocument()
+  })
+})

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import { RecipeFormLayout } from '../RecipeFormLayout'
@@ -160,6 +160,10 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
     vi.clearAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('does not show undo button before any suggestion is applied', () => {

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -154,3 +154,38 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     await waitFor(() => expect(btn).not.toBeDisabled())
   })
 })
+
+describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('does not show undo button before any suggestion is applied', () => {
+    renderWithRouter(makeProps())
+    expect(screen.queryByRole('button', { name: /Undo:/i })).not.toBeInTheDocument()
+  })
+
+  it('shows undo button in header after a suggestion is applied', async () => {
+    mockPostWithAuth.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'description', suggestedValue: 'A tasty pasta dish', reason: 'Improve description' },
+        ],
+      },
+    } as any)
+
+    renderWithRouter(makeProps({ title: 'Pasta' }))
+    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Apply AI suggestion for Description/i })).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Apply AI suggestion for Description/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
+    )
+  })
+})

--- a/tests/ai-authoring.spec.ts
+++ b/tests/ai-authoring.spec.ts
@@ -200,7 +200,7 @@ test.describe('AI-assisted authoring — field suggestions', () => {
     await expect(descriptionField).toHaveValue(SUGGEST_FIELDS_RESPONSE.suggestions[0].suggestedValue)
 
     // The undo button should now appear
-    const undoBtn = page.getByRole('button', { name: /Undo AI/i })
+    const undoBtn = page.getByRole('button', { name: /Undo: Description/i })
     await expect(undoBtn).toBeVisible({ timeout: 3000 })
 
     // Undo the change


### PR DESCRIPTION
## Summary

Add `AIUndoButton` component that appears in the form header after any AI suggestion is applied, showing '↩ Undo: {field}' with 8-second auto-dismiss.

Wires up the existing `canUndo`/`undoLastAIChange` from `useAIAuditTrail` which was already fully implemented but never exposed in the UI.

## Changes

- **New: `AIUndoButton` component** — renders only when there's an undoable change; auto-dismisses after 8s; subtle amber ghost styling consistent with other AI affordances
- **`RecipeFormLayout`** — removed `_` lint-suppression prefix from `_canUndoAI`/`_lastUndoableAIField`; replaced inline undo button in nav with `AIUndoButton` in header area near 'Enhance with AI'
- **`SimpleCreateRecipe`** — wired `canUndo`, `undoLastAIChange`, `auditLog` from `useAISuggestions`; shows `AIUndoButton` in header

## Tests (BDD — written first)
- `AIUndoButton.test.tsx`: 6 tests — null renders nothing, label lookup, fallback key, click handler, 8s auto-dismiss, timer reset on field change
- `RecipeFormLayout.test.tsx`: integration test — undo button appears in header after applying a suggestion

Closes theandiman/recipe-management#42