### PR TITLE
ux: replace emoji spinner with SVG + scope suggestion panel to current step

### DIFF
--- a/src/features/recipes/components/AISpinnerIcon.tsx
+++ b/src/features/recipes/components/AISpinnerIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export const AISpinnerIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    className={`animate-spin ${className ?? 'w-4 h-4'}`}
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+  </svg>
+)

--- a/src/features/recipes/components/AISpinnerIcon.tsx
+++ b/src/features/recipes/components/AISpinnerIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export const AISpinnerIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg
-    className={`animate-spin ${className ?? 'w-4 h-4'}`}
+    className={`animate-spin w-4 h-4${className ? ` ${className}` : ''}`}
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { FIELD_LABELS } from '../constants/aiConstants'
+import { AISpinnerIcon } from './AISpinnerIcon'
+
+const STEP_FIELDS: Record<number, string[]> = {
+  1: ['recipeName', 'description'],
+  4: ['prepTime', 'cookTime', 'servings', 'tags'],
+}
 
 interface AISuggestionPanelProps {
   suggestions: FieldSuggestion[]
@@ -10,21 +16,19 @@ interface AISuggestionPanelProps {
   onDismiss: (field: string) => void
   /** Maps field names to their corresponding form setter functions */
   fieldSetters: Partial<Record<string, (value: string) => void>>
-  /** Current form values keyed by field name — used to record "before" state for the audit trail and to show before/after comparison */
+  /** Current form values keyed by field name */
   currentValues?: Partial<Record<string, string>>
   onRetry?: () => void
+  /** When provided, only suggestions relevant to that step's fields are shown */
+  currentStep?: number
 }
 
 /**
  * Collapsible panel that displays AI-generated field suggestions.
  *
- * - Renders all suggestions passed in via the `suggestions` prop.
+ * - Renders suggestions filtered to the active form step when currentStep is provided.
  * - Each suggestion has an Apply and Dismiss button.
- * - Shows the current field value alongside the suggestion for before/after
- *   comparison when `currentValues` is provided.
- * - Visually distinguished with amber styling and ✨ icon.
- * - If the AI call fails the panel shows an error/retry state but does NOT
- *   block form submission.
+ * - Auto-collapses when success + no visible suggestions for the current step.
  */
 export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   suggestions,
@@ -35,12 +39,23 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   fieldSetters,
   currentValues,
   onRetry,
+  currentStep,
 }) => {
-  const [isExpanded, setIsExpanded] = React.useState(true)
+  const stepFilteredSuggestions =
+    currentStep && STEP_FIELDS[currentStep]
+      ? suggestions.filter(s => STEP_FIELDS[currentStep].includes(s.field))
+      : suggestions
+
+  const autoCollapsed = status === 'success' && stepFilteredSuggestions.length === 0
+  const [isExpanded, setIsExpanded] = React.useState(!autoCollapsed)
+
+  React.useEffect(() => {
+    if (autoCollapsed) setIsExpanded(false)
+  }, [autoCollapsed])
 
   if (status === 'idle') return null
 
-  const hasSuggestions = suggestions.length > 0
+  const hasSuggestions = stepFilteredSuggestions.length > 0
 
   return (
     <div
@@ -60,7 +75,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
           AI Suggestions
           {hasSuggestions && (
             <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-500 text-white text-xs font-bold">
-              {suggestions.length}
+              {stepFilteredSuggestions.length}
             </span>
           )}
         </span>
@@ -72,7 +87,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
           {/* Loading state */}
           {status === 'loading' && (
             <div className="flex items-center gap-2 text-amber-700 text-sm py-2">
-              <span className="animate-spin">⏳</span>
+              <AISpinnerIcon />
               Analysing your recipe for improvement suggestions…
             </div>
           )}
@@ -93,17 +108,10 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
             </div>
           )}
 
-          {/* No suggestions */}
-          {status === 'success' && !hasSuggestions && (
-            <p className="text-sm text-amber-700 py-2">
-              ✅ All fields look good — no suggestions needed.
-            </p>
-          )}
-
           {/* Suggestion cards */}
           {status === 'success' && hasSuggestions && (
             <ul className="space-y-2 mt-1" role="list">
-              {suggestions.map(suggestion => {
+              {stepFilteredSuggestions.map(suggestion => {
                 const setter = fieldSetters[suggestion.field]
                 const label = FIELD_LABELS[suggestion.field] ?? suggestion.field
                 const currentValue = currentValues?.[suggestion.field]

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -1,12 +1,7 @@
 import React from 'react'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
-import { FIELD_LABELS } from '../constants/aiConstants'
+import { FIELD_LABELS, STEP_FIELDS } from '../constants/aiConstants'
 import { AISpinnerIcon } from './AISpinnerIcon'
-
-const STEP_FIELDS: Record<number, string[]> = {
-  1: ['recipeName', 'description'],
-  4: ['prepTime', 'cookTime', 'servings', 'tags'],
-}
 
 interface AISuggestionPanelProps {
   suggestions: FieldSuggestion[]
@@ -29,6 +24,7 @@ interface AISuggestionPanelProps {
  * - Renders suggestions filtered to the active form step when currentStep is provided.
  * - Each suggestion has an Apply and Dismiss button.
  * - Auto-collapses when success + no visible suggestions for the current step.
+ * - Auto-expands when loading or error to ensure the user sees status updates.
  */
 export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   suggestions,
@@ -41,17 +37,26 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   onRetry,
   currentStep,
 }) => {
-  const stepFilteredSuggestions =
-    currentStep && STEP_FIELDS[currentStep]
-      ? suggestions.filter(s => STEP_FIELDS[currentStep].includes(s.field))
-      : suggestions
+  const stepFilteredSuggestions = React.useMemo(() => {
+    if (currentStep === undefined) return suggestions
+    const allowedFields = STEP_FIELDS[currentStep] ?? []
+    // No mapping for this step → show all (steps 2, 3 etc. are not restricted)
+    if (allowedFields.length === 0) return suggestions
+    return suggestions.filter(s => allowedFields.includes(s.field))
+  }, [suggestions, currentStep])
 
   const autoCollapsed = status === 'success' && stepFilteredSuggestions.length === 0
   const [isExpanded, setIsExpanded] = React.useState(!autoCollapsed)
 
   React.useEffect(() => {
-    if (autoCollapsed) setIsExpanded(false)
-  }, [autoCollapsed])
+    if (autoCollapsed) {
+      setIsExpanded(false)
+      return
+    }
+    if (status === 'loading' || status === 'error' || (status === 'success' && stepFilteredSuggestions.length > 0)) {
+      setIsExpanded(true)
+    }
+  }, [autoCollapsed, status, stepFilteredSuggestions.length])
 
   if (status === 'idle') return null
 

--- a/src/features/recipes/components/FieldAIEnhanceButton.tsx
+++ b/src/features/recipes/components/FieldAIEnhanceButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { SuggestionStatus } from '../hooks/useAISuggestions'
+import { AISpinnerIcon } from './AISpinnerIcon'
 
 export interface FieldAIEnhanceButtonProps {
   field: string
@@ -32,7 +33,7 @@ export const FieldAIEnhanceButton: React.FC<FieldAIEnhanceButtonProps> = ({
       className={`inline-flex items-center justify-center w-7 h-7 rounded-md text-amber-400 hover:text-amber-500 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${className ?? ''}`}
     >
       {isLoading ? (
-        <span className="animate-spin text-xs" aria-hidden="true">⏳</span>
+        <AISpinnerIcon className="w-3.5 h-3.5" />
       ) : (
         <span aria-hidden="true">✨</span>
       )}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react'
 import { StepIndicator } from './StepIndicator'
 import { RecipeFormSteps } from './RecipeFormSteps'
+import { AISpinnerIcon } from './AISpinnerIcon'
 
 
 import { RecipePreview } from './RecipePreview'
@@ -377,7 +378,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {suggestionStatus === 'loading' ? (
-                <span className="animate-spin">⏳</span>
+                <AISpinnerIcon />
               ) : (
                 <span aria-hidden="true">✨</span>
               )}
@@ -413,6 +414,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
             tags: tags.join(', '),
           }}
           onRetry={handleRetrySuggestions}
+          currentStep={currentStep}
         />
       )}
 

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -8,6 +8,7 @@ import { InstructionDiffView } from './InstructionDiffView'
 import { FieldAIEnhanceButton } from './FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './FieldAISuggestionChip'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
+import { AISpinnerIcon } from './AISpinnerIcon'
 
 
 interface RecipeFormStepsProps {
@@ -293,7 +294,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 >
                   {generatingAIImage ? (
                     <>
-                      <span className="animate-spin" aria-hidden="true">⏳</span>
+                      <AISpinnerIcon />
                       Generating...
                     </>
                   ) : (
@@ -358,7 +359,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                   >
                     {instructionRefinementLoading === 'loading' ? (
-                      <span className="animate-spin">⏳</span>
+                      <AISpinnerIcon />
                     ) : (
                       <span aria-hidden="true">✨</span>
                     )}

--- a/src/features/recipes/components/__tests__/AISpinnerIcon.test.tsx
+++ b/src/features/recipes/components/__tests__/AISpinnerIcon.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { AISpinnerIcon } from '../AISpinnerIcon'
+
+describe('AISpinnerIcon', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<AISpinnerIcon />)
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('has animate-spin class', () => {
+    const { container } = render(<AISpinnerIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('class')).toContain('animate-spin')
+  })
+
+  it('is aria-hidden', () => {
+    const { container } = render(<AISpinnerIcon />)
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('uses default size class when no className given', () => {
+    const { container } = render(<AISpinnerIcon />)
+    const svg = container.querySelector('svg')
+    const cls = svg?.getAttribute('class') ?? ''
+    expect(cls).toContain('w-4')
+    expect(cls).toContain('h-4')
+  })
+
+  it('accepts a custom className override', () => {
+    const { container } = render(<AISpinnerIcon className="w-6 h-6" />)
+    const svg = container.querySelector('svg')
+    const cls = svg?.getAttribute('class') ?? ''
+    expect(cls).toContain('w-6')
+    expect(cls).toContain('h-6')
+  })
+})

--- a/src/features/recipes/components/__tests__/AISpinnerIcon.test.tsx
+++ b/src/features/recipes/components/__tests__/AISpinnerIcon.test.tsx
@@ -20,7 +20,7 @@ describe('AISpinnerIcon', () => {
     expect(svg?.getAttribute('aria-hidden')).toBe('true')
   })
 
-  it('uses default size class when no className given', () => {
+  it('always includes default w-4 h-4 sizing', () => {
     const { container } = render(<AISpinnerIcon />)
     const svg = container.querySelector('svg')
     const cls = svg?.getAttribute('class') ?? ''
@@ -28,11 +28,15 @@ describe('AISpinnerIcon', () => {
     expect(cls).toContain('h-4')
   })
 
-  it('accepts a custom className override', () => {
-    const { container } = render(<AISpinnerIcon className="w-6 h-6" />)
+  it('appends custom className to defaults', () => {
+    const { container } = render(<AISpinnerIcon className="w-3.5 h-3.5" />)
     const svg = container.querySelector('svg')
     const cls = svg?.getAttribute('class') ?? ''
-    expect(cls).toContain('w-6')
-    expect(cls).toContain('h-6')
+    // defaults still present
+    expect(cls).toContain('w-4')
+    expect(cls).toContain('h-4')
+    // override appended
+    expect(cls).toContain('w-3.5')
+    expect(cls).toContain('h-3.5')
   })
 })

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -69,7 +69,7 @@ describe('AISuggestionPanel', () => {
     expect(onRetry).toHaveBeenCalledOnce()
   })
 
-  it('shows "all fields look good" when status is success and no suggestions', () => {
+  it('auto-collapses (shows only header) when status is success and no suggestions', () => {
     render(
       <AISuggestionPanel
         suggestions={[]}
@@ -80,7 +80,8 @@ describe('AISuggestionPanel', () => {
         fieldSetters={{}}
       />
     )
-    expect(screen.getByText(/all fields look good/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /AI Suggestions/i })).toBeInTheDocument()
+    expect(screen.queryByText(/all fields look good/i)).not.toBeInTheDocument()
   })
 
   it('renders suggestion cards with apply and dismiss buttons', () => {
@@ -270,5 +271,90 @@ describe('Before/after comparison', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: /apply ai suggestion for description/i }))
     expect(onApply).toHaveBeenCalledWith('description', setter, 'My current description')
+  })
+})
+
+// ─── Step-scoped suggestions (issue #45) ─────────────────────────────────────────────
+
+const stepSuggestions: FieldSuggestion[] = [
+  { field: 'recipeName', suggestedValue: 'Better Recipe Name', reason: 'Too generic' },
+  { field: 'description', suggestedValue: 'A rich description', reason: 'Too short' },
+  { field: 'prepTime', suggestedValue: '20', reason: 'Missing prep time' },
+  { field: 'cookTime', suggestedValue: '30', reason: 'Missing cook time' },
+  { field: 'servings', suggestedValue: '4', reason: 'Missing servings' },
+  { field: 'tags', suggestedValue: 'Italian', reason: 'No tags' },
+]
+
+describe('AISuggestionPanel — step scoping', () => {
+  it('filters to step 1 fields (recipeName, description) when currentStep=1', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={stepSuggestions}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{}}
+        currentStep={1}
+      />
+    )
+    expect(screen.getByText(/Better Recipe Name/i)).toBeInTheDocument()
+    expect(screen.getByText(/A rich description/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Missing prep time/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Missing cook time/i)).not.toBeInTheDocument()
+  })
+
+  it('shows step 4 fields (prepTime, cookTime, servings, tags) when currentStep=4', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={stepSuggestions}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{}}
+        currentStep={4}
+      />
+    )
+    expect(screen.getByText(/Missing prep time/i)).toBeInTheDocument()
+    expect(screen.getByText(/Missing cook time/i)).toBeInTheDocument()
+    expect(screen.getByText(/Missing servings/i)).toBeInTheDocument()
+    expect(screen.getByText(/No tags/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Better Recipe Name/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/A rich description/i)).not.toBeInTheDocument()
+  })
+
+  it('shows all suggestions when currentStep is not provided', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={stepSuggestions}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{}}
+      />
+    )
+    expect(screen.getByText(/Better Recipe Name/i)).toBeInTheDocument()
+    expect(screen.getByText(/A rich description/i)).toBeInTheDocument()
+    expect(screen.getByText(/Missing prep time/i)).toBeInTheDocument()
+  })
+
+  it('auto-collapses panel body when success + 0 visible suggestions after step filter', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={[
+          { field: 'prepTime', suggestedValue: '20', reason: 'Missing prep time' },
+        ]}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{}}
+        currentStep={1}
+      />
+    )
+    expect(screen.queryByText(/Missing prep time/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /AI Suggestions/i })).toBeInTheDocument()
   })
 })

--- a/src/features/recipes/constants/aiConstants.ts
+++ b/src/features/recipes/constants/aiConstants.ts
@@ -8,3 +8,9 @@ export const FIELD_LABELS: Record<string, string> = {
   servings: 'Servings',
   tags: 'Tags',
 };
+
+/** Maps form step numbers to the field names shown on that step. */
+export const STEP_FIELDS: Record<number, string[]> = {
+  1: ['recipeName', 'description'],
+  4: ['prepTime', 'cookTime', 'servings', 'tags'],
+};


### PR DESCRIPTION
## Summary

Closes theandiman/recipe-management#45

### Changes

**1. Replace ⏳ emoji spinner with SVG spinner**

Added `AISpinnerIcon` component — a proper spinning SVG that replaces `animate-spin">⏳</span>` everywhere in the AI affordances:
- `FieldAIEnhanceButton` — per-field enhance button
- `AISuggestionPanel` — loading state
- `RecipeFormSteps` — Generate image + Refine all buttons
- `RecipeFormLayout` — top-level Enhance with AI button

**2. Scope `AISuggestionPanel` to current step's fields**

Added `currentStep?: number` prop with a `STEP_FIELDS` map:
- Step 1 → `recipeName`, `description`
- Step 4 → `prepTime`, `cookTime`, `servings`, `tags`
- All other steps (2, 3) or no prop → show all suggestions

Panel auto-collapses (shows only the collapsed header) when `status === 'success'` and no visible suggestions exist for the current step, rather than showing the misleading "All fields look good" message.

### Tests

- `AISpinnerIcon.test.tsx` — SVG renders, has animate-spin, is aria-hidden, respects className
- `AISuggestionPanel.test.tsx` — step 1 filter, step 4 filter, no-step passthrough, auto-collapse