### PR TITLE
fix: use AI API base for recipe generator

### DIFF
--- a/src/features/recipes/recipeSlice.test.ts
+++ b/src/features/recipes/recipeSlice.test.ts
@@ -22,6 +22,7 @@ describe('recipeSlice', () => {
     vi.clearAllMocks()
     // Set default environment variable
     import.meta.env.VITE_API_URL = 'https://api.example.com'
+    delete import.meta.env.VITE_AI_API_URL
   })
 
   afterEach(() => {
@@ -175,6 +176,27 @@ describe('recipeSlice', () => {
       )
     })
 
+    it('prefers VITE_AI_API_URL when generating recipes', async () => {
+      vi.mocked(authApi.postWithAuth).mockResolvedValue({
+        data: { recipeName: 'AI Recipe' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any
+      })
+      import.meta.env.VITE_AI_API_URL = 'https://ai.example.com'
+
+      const store = configureStore({ reducer: { recipe: recipeReducer } })
+      const payload = { prompt: 'test', pantryItems: [] }
+
+      await store.dispatch(generateRecipe(payload))
+
+      expect(authApi.postWithAuth).toHaveBeenCalledWith(
+        'https://ai.example.com/api/recipes/generate',
+        payload
+      )
+    })
+
     it('should handle axios error with string response', async () => {
       const errorMessage = 'Recipe generation failed'
       const axiosError = {
@@ -282,6 +304,28 @@ describe('recipeSlice', () => {
       expect(state.imageError).toBe(null)
       expect(authApi.postWithAuth).toHaveBeenCalledWith(
         'https://api.example.com/api/recipes/image/generate',
+        payload,
+        { signal: expect.any(AbortSignal) }
+      )
+    })
+
+    it('prefers VITE_AI_API_URL when generating images', async () => {
+      vi.mocked(authApi.postWithAuth).mockResolvedValue({
+        data: { imageUrl: 'https://example.com/generated-image.jpg' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any
+      })
+      import.meta.env.VITE_AI_API_URL = 'https://ai.example.com'
+
+      const store = configureStore({ reducer: { recipe: recipeReducer } })
+      const payload = { prompt: 'test' }
+
+      await store.dispatch(generateImage(payload))
+
+      expect(authApi.postWithAuth).toHaveBeenCalledWith(
+        'https://ai.example.com/api/recipes/image/generate',
         payload,
         { signal: expect.any(AbortSignal) }
       )

--- a/src/features/recipes/recipeSlice.test.ts
+++ b/src/features/recipes/recipeSlice.test.ts
@@ -20,13 +20,14 @@ describe('recipeSlice', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    // Set default environment variable
-    import.meta.env.VITE_API_URL = 'https://api.example.com'
-    delete import.meta.env.VITE_AI_API_URL
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com')
+    vi.mocked(axios.isCancel).mockReturnValue(false)
+    vi.mocked(axios.isAxiosError).mockReturnValue(false)
   })
 
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
   })
 
   it('should return initial state', () => {
@@ -172,7 +173,8 @@ describe('recipeSlice', () => {
       expect(state.error).toBe(null)
       expect(authApi.postWithAuth).toHaveBeenCalledWith(
         'https://api.example.com/api/recipes/generate',
-        payload
+        payload,
+        { signal: expect.any(AbortSignal) }
       )
     })
 
@@ -184,7 +186,7 @@ describe('recipeSlice', () => {
         headers: {},
         config: {} as any
       })
-      import.meta.env.VITE_AI_API_URL = 'https://ai.example.com'
+      vi.stubEnv('VITE_AI_API_URL', 'https://ai.example.com')
 
       const store = configureStore({ reducer: { recipe: recipeReducer } })
       const payload = { prompt: 'test', pantryItems: [] }
@@ -193,8 +195,22 @@ describe('recipeSlice', () => {
 
       expect(authApi.postWithAuth).toHaveBeenCalledWith(
         'https://ai.example.com/api/recipes/generate',
-        payload
+        payload,
+        { signal: expect.any(AbortSignal) }
       )
+    })
+
+    it('should handle cancelled recipe generation requests', async () => {
+      const cancelError = new Error('Request cancelled')
+      vi.mocked(authApi.postWithAuth).mockRejectedValue(cancelError)
+      vi.mocked(axios.isCancel).mockReturnValue(true)
+
+      const store = configureStore({ reducer: { recipe: recipeReducer } })
+      await store.dispatch(generateRecipe({ prompt: 'test', pantryItems: [] }))
+
+      const state = store.getState().recipe
+      expect(state.loading).toBe(false)
+      expect(state.error).toBe(null)
     })
 
     it('should handle axios error with string response', async () => {
@@ -317,7 +333,7 @@ describe('recipeSlice', () => {
         headers: {},
         config: {} as any
       })
-      import.meta.env.VITE_AI_API_URL = 'https://ai.example.com'
+      vi.stubEnv('VITE_AI_API_URL', 'https://ai.example.com')
 
       const store = configureStore({ reducer: { recipe: recipeReducer } })
       const payload = { prompt: 'test' }

--- a/src/features/recipes/recipeSlice.ts
+++ b/src/features/recipes/recipeSlice.ts
@@ -4,6 +4,8 @@ import type { Recipe } from '../../types/nutrition'
 import { buildApiUrl } from '../../utils/apiUtils'
 import { postWithAuth } from '../../utils/authApi'
 
+const getAiApiBase = () => import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
+
 export const generateRecipe = createAsyncThunk(
   'recipe/generate',
   async (payload: { 
@@ -13,13 +15,16 @@ export const generateRecipe = createAsyncThunk(
     dietaryPreferences?: string[]; 
     allergies?: string[]; 
     maxTotalMinutes?: number | null 
-  }, { rejectWithValue }) => {
+  }, { rejectWithValue, signal }) => {
     try {
-      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
+      const apiBase = getAiApiBase()
       const url = buildApiUrl(apiBase, '/api/recipes/generate')
-      const res = await postWithAuth(url, payload)
+      const res = await postWithAuth(url, payload, { signal })
       return res.data
     } catch (err) {
+      if (axios.isCancel(err)) {
+        return rejectWithValue('cancelled')
+      }
       if (axios.isAxiosError(err) && err.response) {
         const data = err.response.data
         if (typeof data === 'string') return rejectWithValue(data)
@@ -38,7 +43,7 @@ export const generateImage = createAsyncThunk(
   'recipe/generateImage',
   async (payload: { prompt?: string; recipe?: Recipe }, { rejectWithValue, signal }) => {
     try {
-      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
+      const apiBase = getAiApiBase()
       const url = buildApiUrl(apiBase, '/api/recipes/image/generate')
       const res = await postWithAuth(url, payload, { signal })
       return res.data
@@ -112,7 +117,11 @@ const recipeSlice = createSlice({
       })
       .addCase(generateRecipe.rejected, (state, action) => {
         state.loading = false
-        state.error = (action.payload as string) ?? action.error?.message ?? 'Failed to generate recipe'
+        if (action.payload === 'cancelled') {
+          state.error = null
+        } else {
+          state.error = (action.payload as string) ?? action.error?.message ?? 'Failed to generate recipe'
+        }
       })
       .addCase(generateImage.pending, (state) => {
         state.imageLoading = true

--- a/src/features/recipes/recipeSlice.ts
+++ b/src/features/recipes/recipeSlice.ts
@@ -15,7 +15,7 @@ export const generateRecipe = createAsyncThunk(
     maxTotalMinutes?: number | null 
   }, { rejectWithValue }) => {
     try {
-      const apiBase = import.meta.env.VITE_API_URL || ''
+      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
       const url = buildApiUrl(apiBase, '/api/recipes/generate')
       const res = await postWithAuth(url, payload)
       return res.data
@@ -38,7 +38,7 @@ export const generateImage = createAsyncThunk(
   'recipe/generateImage',
   async (payload: { prompt?: string; recipe?: Recipe }, { rejectWithValue, signal }) => {
     try {
-      const apiBase = import.meta.env.VITE_API_URL || ''
+      const apiBase = import.meta.env.VITE_AI_API_URL || import.meta.env.VITE_API_URL || ''
       const url = buildApiUrl(apiBase, '/api/recipes/image/generate')
       const res = await postWithAuth(url, payload, { signal })
       return res.data


### PR DESCRIPTION
## Summary
- prefer `VITE_AI_API_URL` over `VITE_API_URL` for AI recipe/image generation in the standalone generator flow
- align the generator slice with the rest of the AI hooks
- add regression coverage for AI API base URL precedence

## Validation
- `npm test -- --run src/features/recipes/recipeSlice.test.ts`
- `npm run build` *(currently blocked by pre-existing `FieldSuggestion.source` fixture typing errors outside this PR)*