### PR TITLE
ci: temporarily disable SonarCloud scan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,6 +201,8 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
+    # Temporarily disabled while the hosted SonarCloud scan is hanging and blocking CI.
+    if: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- temporarily disable the hanging `SonarCloud Analysis` job in CI
- keep the change isolated to workflow configuration only
- unblock post-merge validation while SonarCloud is unstable

## Notes
- this is intended as a temporary operational workaround for repeatedly hung SonarCloud scans
- Sonar can be re-enabled in a follow-up once the external issue is resolved