### PR TITLE
feat: use quick entry when editing recipes

### DIFF
--- a/src/components/IngredientInput.tsx
+++ b/src/components/IngredientInput.tsx
@@ -13,7 +13,7 @@ interface IngredientInputProps {
   onDismissNormalization?: (index: number) => void
 }
 
-const COMMON_UNITS = [
+export const COMMON_UNITS = [
   '',
   'tsp',
   'tbsp',

--- a/src/components/Layout/DashboardLayout.test.tsx
+++ b/src/components/Layout/DashboardLayout.test.tsx
@@ -1,126 +1,78 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { RecipeDetail } from '../../features/recipes/RecipeDetail'
-import * as recipeStorageApi from '../../services/recipeStorageApi'
-import type { Recipe } from '../../types/nutrition'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { DashboardLayout } from './DashboardLayout'
 
-// Mock the API
-vi.mock('../../services/recipeStorageApi', () => ({
-  getRecipes: vi.fn(),
-  getRecipe: vi.fn(),
-  deleteRecipe: vi.fn()
-}))
-
-// Mock SavedRecipesContext
-vi.mock('../../features/recipes/SavedRecipesContext', () => ({
-  useSavedRecipes: () => ({
-    savedIds: new Set<string>(),
-    savedRecipes: [],
-    isSaved: () => false,
-    toggleSave: vi.fn().mockResolvedValue(undefined),
-    isLoading: false,
-    reload: vi.fn().mockResolvedValue(undefined)
-  }),
-  SavedRecipesProvider: ({ children }: { children: unknown }) => children
-}))
-
-// Mock useAuth to provide a dummy user without importing the real module
 vi.mock('../../features/auth/AuthContext', () => ({
   useAuth: () => ({
     user: { email: 'test@example.com', uid: 'test-user' },
-    isAuthenticated: true,
-    isLoading: false,
-    error: null,
-    login: async () => {},
-    loginWithGoogle: async () => {},
-    register: async () => {},
-    logout: async () => {}
+    logout: vi.fn(),
   }),
-  AuthProvider: ({ children }: any) => children
 }))
 
-// Mock BookmarkButton to avoid SavedRecipesContext dependencies
-vi.mock('../../components/BookmarkButton', () => ({
-  default: () => null,
-  BookmarkButton: () => null,
+vi.mock('../Dashboard', () => ({
+  Dashboard: () => <div>DashboardStub</div>,
 }))
 
-// Mock LikeButton to avoid LikeContext dependencies
-vi.mock('../../components/LikeButton', () => ({
-  default: () => null,
-  LikeButton: () => null,
+vi.mock('../ThemeToggle', () => ({
+  ThemeToggle: () => <div>ThemeToggleStub</div>,
 }))
 
-// Mock child components that are not under test
-vi.mock('../../components/Dashboard', async () => ({
-  Dashboard: () => <div>DashboardStub</div>
+vi.mock('../../features/recipes/RecipeLibrary', () => ({
+  RecipeLibrary: () => <div>RecipeLibraryStub</div>,
 }))
 
-vi.mock('../../features/recipes/RecipeLibrary', async () => ({
-  RecipeLibrary: () => <div>RecipeLibraryStub</div>
+vi.mock('../../features/recipes/RecipeDetail', () => ({
+  RecipeDetail: () => <div>RecipeDetailStub</div>,
 }))
 
-vi.mock('../../features/recipes/CreateRecipe', async () => ({
-  CreateRecipe: () => <div>CreateRecipeStub</div>
+vi.mock('../../features/recipes/CreateRecipe', () => ({
+  CreateRecipe: () => <div>CreateRecipeStub</div>,
 }))
 
-vi.mock('../../features/recipes/AIGenerator', async () => ({
-  AIGenerator: () => <div>AIGeneratorStub</div>
+vi.mock('../../features/recipes/SimpleCreateRecipe', () => ({
+  SimpleCreateRecipe: () => <div>SimpleCreateRecipeStub</div>,
 }))
 
-const mockRecipe: Recipe = {
-  id: '1',
-  userId: 'user-123',
-  recipeName: 'Chocolate Cake',
-  description: 'Delicious chocolate cake',
-  prepTimeMinutes: 20,
-  cookTimeMinutes: 40,
-  servings: 8,
-  imageUrl: 'https://example.com/cake.jpg',
-  ingredients: ['2 cups flour', '1 cup sugar'],
-  instructions: ['Mix ingredients', 'Bake at 350F'],
-  tags: ['dessert', 'cake'],
-  source: 'ai-generated',
-  createdAt: '2025-01-01T00:00:00Z',
-  updatedAt: '2025-01-01T00:00:00Z'
-}
+vi.mock('../../features/recipes/AIGenerator', () => ({
+  AIGenerator: () => <div>AIGeneratorStub</div>,
+}))
+
+vi.mock('../../features/help/HelpPage', () => ({
+  HelpPage: () => <div>HelpPageStub</div>,
+}))
+
+vi.mock('../../features/community/CommunityPage', () => ({
+  CommunityPage: () => <div>CommunityPageStub</div>,
+}))
+
+vi.mock('../../features/recipes/SavedRecipesPage', () => ({
+  SavedRecipesPage: () => <div>SavedRecipesPageStub</div>,
+}))
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/dashboard/*" element={<DashboardLayout />} />
+      </Routes>
+    </MemoryRouter>
+  )
 
 describe('DashboardLayout routing', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    Object.defineProperty(window, 'innerWidth', { value: 1280, writable: true, configurable: true })
   })
 
-  it('renders RecipeDetail when navigating to /dashboard/recipes/:id', async () => {
-    vi.spyOn(recipeStorageApi, 'getRecipe').mockResolvedValue(mockRecipe)
-    vi.spyOn(recipeStorageApi, 'getRecipes').mockResolvedValue([mockRecipe])
+  it('renders recipe detail for /dashboard/recipes/:id', () => {
+    renderAt('/dashboard/recipes/1')
 
-    render(
-      <MemoryRouter initialEntries={["/dashboard/recipes/1"]}>
-        <Routes>
-          <Route path="/dashboard/recipes/:id" element={<RecipeDetail />} />
-        </Routes>
-      </MemoryRouter>
-    )
+    expect(screen.getByText('RecipeDetailStub')).toBeInTheDocument()
+  })
 
-    // Wait for the recipe title to be fetched and rendered
-    await waitFor(() => {
-      expect(screen.getByText('Chocolate Cake')).toBeInTheDocument()
-    })
+  it('renders quick entry UI for /dashboard/recipes/edit/:id', () => {
+    renderAt('/dashboard/recipes/edit/1')
 
-    // Check that description and prep/cook times show
-    expect(screen.getByText('Delicious chocolate cake')).toBeInTheDocument()
-    // Ensure prep & cook times and servings are displayed within their labeled blocks
-    const prepLabel = screen.getByText('Prep Time')
-    expect(prepLabel).toBeTruthy()
-    expect(prepLabel.parentElement?.textContent).toMatch(/20\s*min/)
-
-    const cookLabel = screen.getByText('Cook Time')
-    expect(cookLabel).toBeTruthy()
-    expect(cookLabel.parentElement?.textContent).toMatch(/40\s*min/)
-
-    const servingsLabel = screen.getByText('Servings')
-    expect(servingsLabel).toBeTruthy()
-    expect(servingsLabel.parentElement?.textContent).toMatch(/8/)
+    expect(screen.getByText('SimpleCreateRecipeStub')).toBeInTheDocument()
   })
 })

--- a/src/components/Layout/DashboardLayout.tsx
+++ b/src/components/Layout/DashboardLayout.tsx
@@ -8,7 +8,6 @@ import { RecipeLibrary } from '../../features/recipes/RecipeLibrary'
 import { RecipeDetail } from '../../features/recipes/RecipeDetail'
 import { CreateRecipe } from '../../features/recipes/CreateRecipe'
 import { SimpleCreateRecipe } from '../../features/recipes/SimpleCreateRecipe'
-import { EditRecipe } from '../../features/recipes/EditRecipe'
 import { AIGenerator } from '../../features/recipes/AIGenerator'
 import { HelpPage } from '../../features/help/HelpPage'
 import { CommunityPage } from '../../features/community/CommunityPage'
@@ -293,7 +292,7 @@ export const DashboardLayout: React.FC = () => {
             <Route index element={<Dashboard />} />
             <Route path="recipes/*" element={<RecipeLibrary />} />
             <Route path="recipes/:id" element={<RecipeDetail />} />
-            <Route path="recipes/edit/:id" element={<EditRecipe />} />
+            <Route path="recipes/edit/:id" element={<SimpleCreateRecipe />} />
             <Route path="create" element={<CreateRecipe />} />
             <Route path="create/simple" element={<SimpleCreateRecipe />} />
             <Route path="generate" element={<AIGenerator />} />

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -63,7 +63,7 @@ const mockRecipe: Recipe = {
   tags: ['breakfast', 'easy'],
   dietaryRestrictions: ['vegetarian'],
   source: 'ai-generated' as const,
-  nutritionalInfo: { calories: 200 },
+  nutritionalInfo: { perServing: { calories: 200 } },
   tips: { storage: 'Use room temperature eggs' },
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -367,7 +367,7 @@ describe('SimpleCreateRecipe', () => {
           expect.objectContaining({
             recipeName: 'Test Recipe',
             source: 'ai-generated',
-            nutritionalInfo: { calories: 200 },
+            nutritionalInfo: { perServing: { calories: 200 } },
             tips: { storage: 'Use room temperature eggs' },
           })
         )

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
-import { BrowserRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { SimpleCreateRecipe } from './SimpleCreateRecipe'
+import * as recipeStorageApi from '../../services/recipeStorageApi'
+import { useAuth } from '../auth/AuthContext'
+import type { Recipe } from '../../types/nutrition'
 
 vi.mock('../../services/recipeStorageApi', () => ({
   saveRecipe: vi.fn(() =>
@@ -17,6 +20,8 @@ vi.mock('../../services/recipeStorageApi', () => ({
       updatedAt: new Date().toISOString(),
     })
   ),
+  updateRecipe: vi.fn(() => Promise.resolve(undefined)),
+  getRecipe: vi.fn(),
 }))
 
 vi.mock('../../utils/authApi', () => ({
@@ -25,6 +30,10 @@ vi.mock('../../utils/authApi', () => ({
 
 vi.mock('../../utils/apiUtils', () => ({
   buildApiUrl: vi.fn((_base: string, endpoint: string) => endpoint),
+}))
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: vi.fn(),
 }))
 
 const mockNavigate = vi.fn()
@@ -36,13 +45,65 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
-const renderWithRouter = (component: React.ReactElement) =>
-  render(<BrowserRouter>{component}</BrowserRouter>)
+type MockAuthState = ReturnType<typeof useAuth>
+type EditableMockRecipe = Omit<Recipe, 'prepTime' | 'cookTime'> & {
+  prepTime: number
+  cookTime: number
+}
+
+const mockRecipe = {
+  id: 'test-recipe-123',
+  recipeName: 'Test Recipe',
+  description: 'A quick edit recipe',
+  userId: 'test-user',
+  ingredients: ['1 cup flour', '2 eggs'],
+  instructions: ['Mix ingredients', 'Bake'],
+  servings: 4,
+  prepTime: 10,
+  cookTime: 20,
+  imageUrl: 'https://example.com/image.jpg',
+  tags: ['breakfast', 'easy'],
+  dietaryRestrictions: ['vegetarian'],
+  source: 'ai-generated' as const,
+  nutritionalInfo: { calories: 200 },
+  tips: ['Use room temperature eggs'],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+} as unknown as EditableMockRecipe
+
+const renderWithRouter = (
+  component: React.ReactElement,
+  initialEntry = '/dashboard/create/simple',
+  routePath = '/dashboard/create/simple'
+) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path={routePath} element={component} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+const setDefaultAuthMock = (overrides: Partial<MockAuthState> = {}) => {
+  vi.mocked(useAuth).mockReturnValue({
+    user: {
+      uid: 'test-user',
+      email: 'test@example.com',
+      displayName: null,
+      photoURL: null,
+    },
+    isLoading: false,
+    ...overrides,
+  } as MockAuthState)
+}
 
 describe('SimpleCreateRecipe', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     sessionStorage.clear()
+    Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true })
+    setDefaultAuthMock()
+    vi.mocked(recipeStorageApi.getRecipe).mockResolvedValue(mockRecipe as unknown as Recipe)
   })
 
   // ─── Layout ──────────────────────────────────────────────────────────────────
@@ -239,11 +300,101 @@ describe('SimpleCreateRecipe', () => {
     fireEvent.click(screen.getByRole('button', { name: /Cancel/i }))
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard/recipes')
   })
+
+  describe('edit mode', () => {
+    const editRoute = '/dashboard/recipes/edit/:id'
+    const editEntry = '/dashboard/recipes/edit/test-recipe-123'
+
+    it('loads existing recipe data into the quick entry form', async () => {
+      renderWithRouter(<SimpleCreateRecipe />, editEntry, editRoute)
+
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: /Edit Recipe/i })).toBeInTheDocument()
+      })
+
+      expect(recipeStorageApi.getRecipe).toHaveBeenCalledWith('test-recipe-123')
+      expect(screen.getByDisplayValue('Test Recipe')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('A quick edit recipe')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('flour')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Bake')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Update Recipe/i })).toBeInTheDocument()
+    })
+
+    it('shows a load error state for edit mode', async () => {
+      vi.mocked(recipeStorageApi.getRecipe).mockRejectedValueOnce(new Error('Network error'))
+
+      renderWithRouter(<SimpleCreateRecipe />, editEntry, editRoute)
+
+      await waitFor(() => {
+        expect(screen.getByText('Error loading recipe')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Back to Library/i })).toBeInTheDocument()
+    })
+
+    it('redirects to recipe detail when the current user does not own the recipe', async () => {
+      setDefaultAuthMock({
+        user: {
+          uid: 'another-user',
+          email: 'test@example.com',
+          displayName: null,
+          photoURL: null,
+        },
+      })
+
+      renderWithRouter(<SimpleCreateRecipe />, editEntry, editRoute)
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard/recipes/test-recipe-123', { replace: true })
+      })
+    })
+
+    it('updates the recipe and returns to recipe detail on submit', async () => {
+      renderWithRouter(<SimpleCreateRecipe />, editEntry, editRoute)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Update Recipe/i })).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /Update Recipe/i }))
+
+      await waitFor(() => {
+        expect(recipeStorageApi.updateRecipe).toHaveBeenCalledWith(
+          'test-recipe-123',
+          expect.objectContaining({
+            recipeName: 'Test Recipe',
+            source: 'ai-generated',
+            nutritionalInfo: { calories: 200 },
+            tips: ['Use room temperature eggs'],
+          })
+        )
+      })
+
+      expect(recipeStorageApi.saveRecipe).not.toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard/recipes/test-recipe-123')
+    })
+
+    it('returns to recipe detail when Cancel is clicked in edit mode', async () => {
+      renderWithRouter(<SimpleCreateRecipe />, editEntry, editRoute)
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /Cancel/i }))
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard/recipes/test-recipe-123')
+    })
+  })
 })
 
 // ─── AI Enhancement (issue #36) ──────────────────────────────────────────────
 
 describe('AI Enhancement', () => {
+  beforeEach(() => {
+    setDefaultAuthMock()
+  })
+
   it('renders the "Enhance with AI" button', () => {
     renderWithRouter(<SimpleCreateRecipe />)
     expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
@@ -276,6 +427,7 @@ describe('AI Undo Affordance', () => {
     vi.resetAllMocks()
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setDefaultAuthMock()
   })
 
   afterEach(() => {
@@ -295,7 +447,7 @@ describe('AI Undo Affordance', () => {
           { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
         ],
       },
-    } as any)
+    } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
     fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
@@ -323,7 +475,7 @@ describe('AI Undo Affordance', () => {
           { field: 'description', suggestedValue: 'Delicious pasta', reason: 'Better description' },
         ],
       },
-    } as any)
+    } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
     fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -46,30 +46,28 @@ vi.mock('react-router-dom', async () => {
 })
 
 type MockAuthState = ReturnType<typeof useAuth>
-type EditableMockRecipe = Omit<Recipe, 'prepTime' | 'cookTime'> & {
-  prepTime: number
-  cookTime: number
-}
 
-const mockRecipe = {
+const mockRecipe: Recipe = {
   id: 'test-recipe-123',
   recipeName: 'Test Recipe',
   description: 'A quick edit recipe',
   userId: 'test-user',
-  ingredients: ['1 cup flour', '2 eggs'],
+  ingredients: ['1 cup flour', '2 eggs', 'Salt'],
   instructions: ['Mix ingredients', 'Bake'],
   servings: 4,
-  prepTime: 10,
-  cookTime: 20,
+  prepTime: '10 min',
+  cookTime: '20 min',
+  prepTimeMinutes: 10,
+  cookTimeMinutes: 20,
   imageUrl: 'https://example.com/image.jpg',
   tags: ['breakfast', 'easy'],
   dietaryRestrictions: ['vegetarian'],
   source: 'ai-generated' as const,
   nutritionalInfo: { calories: 200 },
-  tips: ['Use room temperature eggs'],
+  tips: { storage: 'Use room temperature eggs' },
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
-} as unknown as EditableMockRecipe
+}
 
 const renderWithRouter = (
   component: React.ReactElement,
@@ -103,7 +101,7 @@ describe('SimpleCreateRecipe', () => {
     sessionStorage.clear()
     Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true })
     setDefaultAuthMock()
-    vi.mocked(recipeStorageApi.getRecipe).mockResolvedValue(mockRecipe as unknown as Recipe)
+    vi.mocked(recipeStorageApi.getRecipe).mockResolvedValue(mockRecipe)
   })
 
   // ─── Layout ──────────────────────────────────────────────────────────────────
@@ -315,7 +313,11 @@ describe('SimpleCreateRecipe', () => {
       expect(recipeStorageApi.getRecipe).toHaveBeenCalledWith('test-recipe-123')
       expect(screen.getByDisplayValue('Test Recipe')).toBeInTheDocument()
       expect(screen.getByDisplayValue('A quick edit recipe')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('10')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('20')).toBeInTheDocument()
       expect(screen.getByDisplayValue('flour')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('eggs')).toBeInTheDocument()
+      expect(screen.getAllByDisplayValue('Salt')).toHaveLength(1)
       expect(screen.getByDisplayValue('Bake')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /Update Recipe/i })).toBeInTheDocument()
     })
@@ -366,7 +368,7 @@ describe('SimpleCreateRecipe', () => {
             recipeName: 'Test Recipe',
             source: 'ai-generated',
             nutritionalInfo: { calories: 200 },
-            tips: ['Use room temperature eggs'],
+            tips: { storage: 'Use room temperature eggs' },
           })
         )
       })

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -4,7 +4,7 @@ import { useRecipeForm } from './hooks/useRecipeForm'
 import { useRecipeValidation } from './hooks/useRecipeValidation'
 import { useRecipeSave } from './hooks/useRecipeSave'
 import { CollapsibleSection } from './components/CollapsibleSection'
-import { IngredientInput } from '../../components/IngredientInput'
+import { COMMON_UNITS, IngredientInput } from '../../components/IngredientInput'
 import { UI_STYLES } from '../../utils/uiStyles'
 import { clampedNumericHandler } from '../../utils/formUtils'
 import { useSimpleCreateSections } from './hooks/useSimpleCreateSections'
@@ -20,27 +20,38 @@ import { useAuth } from '../auth/AuthContext'
 import type { Recipe } from '../../types/nutrition'
 
 type RecipeFormInitialState = Parameters<typeof useRecipeForm>[0]
-type EditableRecipe = Omit<Recipe, 'prepTime' | 'cookTime'> & {
-  prepTime?: number
-  cookTime?: number
-}
 
 const EMPTY_INGREDIENT = { quantity: '', unit: '', item: '' }
+const KNOWN_INGREDIENT_UNITS = new Set(COMMON_UNITS.filter(Boolean))
+const QUANTITY_PATTERN = /^(\d+(?:\.\d+)?|\d+\/\d+|\d+\s+\d+\/\d+|[¼½¾⅐⅑⅒⅓⅔⅕⅖⅗⅘⅙⅚⅛⅜⅝⅞])$/
 
 const mapIngredientStringToFormValue = (ingredient: string) => {
-  const parts = ingredient.split(' ')
-  const quantity = parts[0] || ''
-  const unit = parts[1] || ''
-  const item = parts.slice(2).join(' ') || ingredient
+  const trimmedIngredient = ingredient.trim()
+
+  if (!trimmedIngredient) {
+    return EMPTY_INGREDIENT
+  }
+
+  const parts = trimmedIngredient.split(/\s+/)
+
+  if (parts.length === 1 || !QUANTITY_PATTERN.test(parts[0])) {
+    return { quantity: '', unit: '', item: trimmedIngredient }
+  }
+
+  const quantity = parts[0]
+  const normalizedUnit = parts[1]?.toLowerCase() || ''
+  const hasKnownUnit = KNOWN_INGREDIENT_UNITS.has(normalizedUnit)
+  const unit = hasKnownUnit ? parts[1] : ''
+  const item = hasKnownUnit ? parts.slice(2).join(' ') : parts.slice(1).join(' ')
 
   return { quantity, unit, item }
 }
 
-const getInitialFormState = (recipe: EditableRecipe): RecipeFormInitialState => ({
+const getInitialFormState = (recipe: Recipe): RecipeFormInitialState => ({
   title: recipe.recipeName || '',
   description: recipe.description || '',
-  prepTime: recipe.prepTime?.toString() || '',
-  cookTime: recipe.cookTime?.toString() || '',
+  prepTime: recipe.prepTimeMinutes?.toString() || '',
+  cookTime: recipe.cookTimeMinutes?.toString() || '',
   servings: recipe.servings?.toString() || '',
   ingredients: recipe.ingredients?.length
     ? recipe.ingredients.map(mapIngredientStringToFormValue)
@@ -855,7 +866,7 @@ export const SimpleCreateRecipe: React.FC = () => {
       try {
         setLoading(true)
         setLoadError(null)
-        const recipe = await getRecipe(id) as EditableRecipe
+        const recipe = await getRecipe(id)
 
         if (recipe.userId !== currentUser?.uid) {
           navigate(`/dashboard/recipes/${id}`, { replace: true })

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useRecipeForm } from './hooks/useRecipeForm'
 import { useRecipeValidation } from './hooks/useRecipeValidation'
 import { useRecipeSave } from './hooks/useRecipeSave'
@@ -15,15 +15,63 @@ import { FieldAIEnhanceButton } from './components/FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './components/FieldAISuggestionChip'
 import { AIUndoButton } from './components/AIUndoButton'
 import { FIELD_LABELS } from './constants/aiConstants'
+import { getRecipe } from '../../services/recipeStorageApi'
+import { useAuth } from '../auth/AuthContext'
+import type { Recipe } from '../../types/nutrition'
 
-export const SimpleCreateRecipe: React.FC = () => {
+type RecipeFormInitialState = Parameters<typeof useRecipeForm>[0]
+type EditableRecipe = Omit<Recipe, 'prepTime' | 'cookTime'> & {
+  prepTime?: number
+  cookTime?: number
+}
+
+const EMPTY_INGREDIENT = { quantity: '', unit: '', item: '' }
+
+const mapIngredientStringToFormValue = (ingredient: string) => {
+  const parts = ingredient.split(' ')
+  const quantity = parts[0] || ''
+  const unit = parts[1] || ''
+  const item = parts.slice(2).join(' ') || ingredient
+
+  return { quantity, unit, item }
+}
+
+const getInitialFormState = (recipe: EditableRecipe): RecipeFormInitialState => ({
+  title: recipe.recipeName || '',
+  description: recipe.description || '',
+  prepTime: recipe.prepTime?.toString() || '',
+  cookTime: recipe.cookTime?.toString() || '',
+  servings: recipe.servings?.toString() || '',
+  ingredients: recipe.ingredients?.length
+    ? recipe.ingredients.map(mapIngredientStringToFormValue)
+    : [EMPTY_INGREDIENT],
+  instructions: recipe.instructions?.length ? recipe.instructions : [''],
+  tags: recipe.tags || [],
+  dietaryRestrictions: recipe.dietaryRestrictions || [],
+  imagePreview: recipe.imageUrl || null,
+})
+
+interface QuickEntryRecipeFormProps {
+  isEditMode: boolean
+  recipeId?: string
+  initialState?: RecipeFormInitialState
+  recipeOverrides?: Partial<Recipe>
+}
+
+const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
+  isEditMode,
+  recipeId,
+  initialState,
+  recipeOverrides = {},
+}) => {
   const navigate = useNavigate()
 
-  const form = useRecipeForm()
+  const form = useRecipeForm(initialState)
   const { validateForm, buildRecipeObject } = useRecipeValidation()
   const sections = useSimpleCreateSections()
 
   const { handleSubmit } = useRecipeSave({
+    recipeId,
     title: form.title,
     description: form.description,
     prepTime: form.prepTime,
@@ -34,6 +82,7 @@ export const SimpleCreateRecipe: React.FC = () => {
     tags: form.tags,
     dietaryRestrictions: form.dietaryRestrictions,
     imagePreview: form.imagePreview,
+    recipeOverrides,
     setFieldErrors: form.setFieldErrors,
     setStepsWithErrors: form.setStepsWithErrors,
     setSaveLoading: form.setSaveLoading,
@@ -45,8 +94,8 @@ export const SimpleCreateRecipe: React.FC = () => {
   })
 
   const handleCancel = useCallback(() => {
-    navigate('/dashboard/recipes')
-  }, [navigate])
+    navigate(isEditMode && recipeId ? `/dashboard/recipes/${recipeId}` : '/dashboard/recipes')
+  }, [isEditMode, navigate, recipeId])
 
   const {
     visibleSuggestions,
@@ -124,10 +173,12 @@ export const SimpleCreateRecipe: React.FC = () => {
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
-      {/* Header */}
+        {/* Header */}
       <div className="mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">Create Recipe</h1>
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">
+            {isEditMode ? 'Edit Recipe' : 'Create Recipe'}
+          </h1>
           <div className="flex items-center gap-2">
             <AIUndoButton
               key={auditLog.length}
@@ -153,28 +204,31 @@ export const SimpleCreateRecipe: React.FC = () => {
         </div>
 
         {/* Entry-point mode toggle */}
-        <nav
-          className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 mb-6"
-          aria-label="Recipe creation mode"
-        >
-          <Link
-            to="/dashboard/create"
-            className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-white transition-colors"
+        {!isEditMode && (
+          <nav
+            className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 mb-6"
+            aria-label="Recipe creation mode"
           >
-            🧭 Guided (step-by-step)
-          </Link>
-          <Link
-            to="/dashboard/create/simple"
-            aria-current="page"
-            className="px-4 py-2 rounded-md text-sm font-medium bg-white text-emerald-700 shadow-sm border border-gray-200"
-          >
-            ⚡ Quick entry
-          </Link>
-        </nav>
+            <Link
+              to="/dashboard/create"
+              className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-white transition-colors"
+            >
+              🧭 Guided (step-by-step)
+            </Link>
+            <Link
+              to="/dashboard/create/simple"
+              aria-current="page"
+              className="px-4 py-2 rounded-md text-sm font-medium bg-white text-emerald-700 shadow-sm border border-gray-200"
+            >
+              ⚡ Quick entry
+            </Link>
+          </nav>
+        )}
 
         <p className="text-sm text-gray-500">
-          Fill in everything at once. Required fields are always visible; optional sections can be
-          expanded as needed.
+          {isEditMode
+            ? 'Update everything at once. Required fields are always visible; optional sections can be expanded as needed.'
+            : 'Fill in everything at once. Required fields are always visible; optional sections can be expanded as needed.'}
         </p>
       </div>
 
@@ -762,14 +816,118 @@ export const SimpleCreateRecipe: React.FC = () => {
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
                   />
                 </svg>
-                <span>Saving…</span>
+                <span>{isEditMode ? 'Updating…' : 'Saving…'}</span>
               </span>
             ) : (
-              'Save Recipe'
+              isEditMode ? 'Update Recipe' : 'Save Recipe'
             )}
           </button>
         </div>
       </form>
     </div>
+  )
+}
+
+export const SimpleCreateRecipe: React.FC = () => {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
+  const { user: currentUser, isLoading: isAuthLoading } = useAuth()
+  const isEditMode = Boolean(id)
+  const [loading, setLoading] = useState(isEditMode)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [initialState, setInitialState] = useState<RecipeFormInitialState>()
+  const [recipeOverrides, setRecipeOverrides] = useState<Partial<Recipe>>({})
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setLoading(false)
+      setLoadError(null)
+      setInitialState(undefined)
+      setRecipeOverrides({})
+      return
+    }
+
+    if (!id || isAuthLoading) return
+
+    let isMounted = true
+
+    const fetchRecipeForEdit = async () => {
+      try {
+        setLoading(true)
+        setLoadError(null)
+        const recipe = await getRecipe(id) as EditableRecipe
+
+        if (recipe.userId !== currentUser?.uid) {
+          navigate(`/dashboard/recipes/${id}`, { replace: true })
+          return
+        }
+
+        if (!isMounted) return
+
+        setInitialState(getInitialFormState(recipe))
+        setRecipeOverrides({
+          nutritionalInfo: recipe.nutritionalInfo,
+          tips: recipe.tips,
+          source: recipe.source,
+        })
+      } catch (err: unknown) {
+        if (!isMounted) return
+
+        console.error('Failed to fetch recipe:', err)
+        const errorMessage = err instanceof Error ? err.message : 'Failed to load recipe'
+        const apiError = err as { response?: { data?: { message?: string } } }
+        setLoadError(apiError.response?.data?.message || errorMessage)
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchRecipeForEdit()
+
+    return () => {
+      isMounted = false
+    }
+  }, [currentUser?.uid, id, isAuthLoading, isEditMode, navigate])
+
+  if (isEditMode && loading) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600"></div>
+        </div>
+      </div>
+    )
+  }
+
+  if (isEditMode && loadError) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <button
+          onClick={() => navigate('/dashboard/recipes')}
+          className="mb-6 text-emerald-600 hover:text-emerald-700 flex items-center transition-colors"
+        >
+          <svg className="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          Back to Library
+        </button>
+        <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg p-4">
+          <p className="font-medium">Error loading recipe</p>
+          <p className="text-sm mt-1">{loadError}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <QuickEntryRecipeForm
+      key={id ?? 'create'}
+      isEditMode={isEditMode}
+      recipeId={id}
+      initialState={initialState}
+      recipeOverrides={recipeOverrides}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- route recipe editing through the quick-entry UI
- load existing recipe data into the quick-entry form for edit mode
- preserve ownership checks, update semantics, and navigation with edit-mode regression coverage

## Validation
- `npm test -- --run src/features/recipes/SimpleCreateRecipe.test.tsx src/components/Layout/DashboardLayout.test.tsx`

Resolves #318