### PR TITLE
feat: add AI value completion to recipe forms

### DIFF
--- a/src/features/recipes/CreateRecipe.tsx
+++ b/src/features/recipes/CreateRecipe.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { RecipeFormLayout } from './components/RecipeFormLayout'
 import { useRecipeForm } from './hooks/useRecipeForm'
@@ -7,6 +7,7 @@ import { useRecipeFormNavigation } from './hooks/useRecipeFormNavigation'
 import { useRecipeSave } from './hooks/useRecipeSave'
 import { useAISuggestions } from './hooks/useAISuggestions'
 import { useIngredientNormalization } from './hooks/useIngredientNormalization'
+import type { Recipe } from '../../types/nutrition'
 
 const FIELD_LABELS: Record<string, string> = {
   recipeName: 'Recipe Name',
@@ -23,6 +24,7 @@ export const CreateRecipe: React.FC = () => {
   const form = useRecipeForm()
   const { validateForm, buildRecipeObject } = useRecipeValidation()
   const { canUndo, auditLog, undoLastAIChange } = useAISuggestions()
+  const [recipeOverrides, setRecipeOverrides] = useState<Partial<Recipe>>({})
   const {
     normalizationStates,
     applyNormalization,
@@ -40,6 +42,7 @@ export const CreateRecipe: React.FC = () => {
     tags: form.tags,
     dietaryRestrictions: form.dietaryRestrictions,
     imagePreview: form.imagePreview,
+    recipeOverrides,
     setFieldErrors: form.setFieldErrors,
     setStepsWithErrors: form.setStepsWithErrors,
     setSaveLoading: form.setSaveLoading,
@@ -126,6 +129,10 @@ export const CreateRecipe: React.FC = () => {
         canUndoAI={canUndo}
         onUndoLastAI={handleUndoLastAI}
         lastUndoableAIField={lastUndoableAIField}
+        nutritionalInfo={recipeOverrides.nutritionalInfo}
+        onNutritionalInfoChange={(nutritionalInfo) =>
+          setRecipeOverrides((prev) => ({ ...prev, nutritionalInfo }))
+        }
         normalizationStates={normalizationStates}
         onApplyNormalization={applyNormalization}
         onDismissNormalization={dismissNormalization}

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -420,6 +420,74 @@ describe('AI Enhancement', () => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
     })
   })
+
+  it('saves accepted AI nutrition estimates with the recipe', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        perServing: {
+          calories: { value: 220, unit: 'kcal', estimated: true },
+          protein: { value: 8, unit: 'g', estimated: true },
+          carbs: { value: 30, unit: 'g', estimated: true },
+          fat: { value: 6, unit: 'g', estimated: true },
+          fiber: { value: 4, unit: 'g', estimated: true },
+          warnings: [],
+          isPartial: false,
+        },
+        wholeRecipe: {
+          calories: { value: 880, unit: 'kcal', estimated: true },
+          protein: { value: 32, unit: 'g', estimated: true },
+          carbs: { value: 120, unit: 'g', estimated: true },
+          fat: { value: 24, unit: 'g', estimated: true },
+          fiber: { value: 16, unit: 'g', estimated: true },
+          warnings: [],
+          isPartial: false,
+        },
+      },
+    } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    renderWithRouter(<SimpleCreateRecipe />)
+
+    fireEvent.change(screen.getByPlaceholderText(/Grandma's Chocolate Chip Cookies/i), {
+      target: { value: 'AI Nutrition Pasta' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/all-purpose flour/i), {
+      target: { value: 'flour' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/Describe this step in detail/i), {
+      target: { value: 'Mix everything together.' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Nutrition/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Calculate Missing Nutrition with AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Accept/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Accept/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Save Recipe/i }))
+
+    await waitFor(() => {
+      expect(recipeStorageApi.saveRecipe).toHaveBeenCalledWith(expect.objectContaining({
+        nutritionalInfo: {
+          perServing: {
+            calories: 220,
+            protein: 8,
+            carbohydrates: 30,
+            fat: 6,
+            fiber: 4,
+          },
+          total: {
+            calories: 880,
+            protein: 32,
+            carbohydrates: 120,
+            fat: 24,
+            fiber: 16,
+          },
+        },
+      }))
+    })
+  })
 })
 
 // ─── AI Undo Affordance (issue #42) ──────────────────────────────────────────

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -18,6 +18,9 @@ import { FIELD_LABELS } from './constants/aiConstants'
 import { getRecipe } from '../../services/recipeStorageApi'
 import { useAuth } from '../auth/AuthContext'
 import type { Recipe } from '../../types/nutrition'
+import { mapEstimateToNutritionalInfo, useNutritionEstimate } from './hooks/useNutritionEstimate'
+import { NutritionEstimatePanel } from './components/NutritionEstimatePanel'
+import NutritionFacts from '../../components/NutritionFacts'
 
 type RecipeFormInitialState = Parameters<typeof useRecipeForm>[0]
 
@@ -76,10 +79,15 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
   recipeOverrides = {},
 }) => {
   const navigate = useNavigate()
+  const [activeRecipeOverrides, setActiveRecipeOverrides] = useState<Partial<Recipe>>(recipeOverrides)
 
   const form = useRecipeForm(initialState)
   const { validateForm, buildRecipeObject } = useRecipeValidation()
   const sections = useSimpleCreateSections()
+
+  useEffect(() => {
+    setActiveRecipeOverrides(recipeOverrides)
+  }, [recipeOverrides])
 
   const { handleSubmit } = useRecipeSave({
     recipeId,
@@ -93,7 +101,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     tags: form.tags,
     dietaryRestrictions: form.dietaryRestrictions,
     imagePreview: form.imagePreview,
-    recipeOverrides,
+    recipeOverrides: activeRecipeOverrides,
     setFieldErrors: form.setFieldErrors,
     setStepsWithErrors: form.setStepsWithErrors,
     setSaveLoading: form.setSaveLoading,
@@ -121,6 +129,14 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     undoLastAIChange,
     auditLog,
   } = useAISuggestions()
+  const {
+    estimate: nutritionEstimate,
+    loadingState: nutritionLoadingState,
+    error: nutritionError,
+    estimateNutrition,
+    clearEstimate: clearNutritionEstimate,
+    acceptEstimate: acceptNutritionEstimate,
+  } = useNutritionEstimate()
 
   const buildSuggestionRequest = () => ({
     recipeName: form.title || undefined,
@@ -181,6 +197,17 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     const setter = fieldSetters[result.field]
     if (setter) setter(String(result.previousValue ?? ''))
   }, [undoLastAIChange, fieldSetters])
+  const hasIngredients = form.ingredients.some((ingredient) => ingredient.item.trim())
+  const hasSavedNutrition = Boolean(activeRecipeOverrides.nutritionalInfo?.perServing)
+
+  const handleAcceptNutritionEstimate = useCallback(() => {
+    acceptNutritionEstimate((estimate) => {
+      setActiveRecipeOverrides((prev) => ({
+        ...prev,
+        nutritionalInfo: mapEstimateToNutritionalInfo(estimate),
+      }))
+    })
+  }, [acceptNutritionEstimate])
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
@@ -534,12 +561,20 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
           >
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label
-                  htmlFor="simple-prep-time"
-                  className="block text-sm font-semibold text-gray-700 mb-2"
-                >
-                  Prep Time (min)
-                </label>
+                <div className="flex items-center gap-1.5 mb-2">
+                  <label
+                    htmlFor="simple-prep-time"
+                    className="block text-sm font-semibold text-gray-700"
+                  >
+                    Prep Time (min)
+                  </label>
+                  <FieldAIEnhanceButton
+                    field="prepTime"
+                    currentValue={form.prepTime}
+                    status={fieldStatus.get('prepTime') ?? 'idle'}
+                    onEnhance={() => handleEnhanceField('prepTime', form.prepTime)}
+                  />
+                </div>
                 <input
                   id="simple-prep-time"
                   type="number"
@@ -551,14 +586,34 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   placeholder="15"
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
+                {(() => {
+                  const s = visibleSuggestions.find(x => x.field === 'prepTime')
+                  return s ? (
+                    <FieldAISuggestionChip
+                      field="prepTime"
+                      suggestion={s.suggestedValue}
+                      currentValue={form.prepTime}
+                      onApply={() => handleApplyFieldSuggestion('prepTime', s.suggestedValue)}
+                      onDismiss={() => dismissSuggestion('prepTime')}
+                    />
+                  ) : null
+                })()}
               </div>
               <div>
-                <label
-                  htmlFor="simple-cook-time"
-                  className="block text-sm font-semibold text-gray-700 mb-2"
-                >
-                  Cook Time (min)
-                </label>
+                <div className="flex items-center gap-1.5 mb-2">
+                  <label
+                    htmlFor="simple-cook-time"
+                    className="block text-sm font-semibold text-gray-700"
+                  >
+                    Cook Time (min)
+                  </label>
+                  <FieldAIEnhanceButton
+                    field="cookTime"
+                    currentValue={form.cookTime}
+                    status={fieldStatus.get('cookTime') ?? 'idle'}
+                    onEnhance={() => handleEnhanceField('cookTime', form.cookTime)}
+                  />
+                </div>
                 <input
                   id="simple-cook-time"
                   type="number"
@@ -570,6 +625,18 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   placeholder="30"
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
+                {(() => {
+                  const s = visibleSuggestions.find(x => x.field === 'cookTime')
+                  return s ? (
+                    <FieldAISuggestionChip
+                      field="cookTime"
+                      suggestion={s.suggestedValue}
+                      currentValue={form.cookTime}
+                      onApply={() => handleApplyFieldSuggestion('cookTime', s.suggestedValue)}
+                      onDismiss={() => dismissSuggestion('cookTime')}
+                    />
+                  ) : null
+                })()}
               </div>
             </div>
           </CollapsibleSection>
@@ -584,12 +651,20 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
             data-testid="section-serving"
           >
             <div>
-              <label
-                htmlFor="simple-servings"
-                className="block text-sm font-semibold text-gray-700 mb-2"
-              >
-                Servings
-              </label>
+              <div className="flex items-center gap-1.5 mb-2">
+                <label
+                  htmlFor="simple-servings"
+                  className="block text-sm font-semibold text-gray-700"
+                >
+                  Servings
+                </label>
+                <FieldAIEnhanceButton
+                  field="servings"
+                  currentValue={form.servings}
+                  status={fieldStatus.get('servings') ?? 'idle'}
+                  onEnhance={() => handleEnhanceField('servings', form.servings)}
+                />
+              </div>
               <input
                 id="simple-servings"
                 type="number"
@@ -601,6 +676,62 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 placeholder="4"
                 className="w-full sm:w-40 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
               />
+              {(() => {
+                const s = visibleSuggestions.find(x => x.field === 'servings')
+                return s ? (
+                  <FieldAISuggestionChip
+                    field="servings"
+                    suggestion={s.suggestedValue}
+                    currentValue={form.servings}
+                    onApply={() => handleApplyFieldSuggestion('servings', s.suggestedValue)}
+                    onDismiss={() => dismissSuggestion('servings')}
+                  />
+                ) : null
+              })()}
+            </div>
+          </CollapsibleSection>
+
+          <CollapsibleSection
+            title="Nutrition"
+            icon="🥗"
+            isOpen={sections.nutrition.isOpen}
+            isFilled={sections.nutrition.isFilled(hasSavedNutrition)}
+            onToggle={sections.nutrition.toggle}
+            data-testid="section-nutrition"
+          >
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600">
+                Let AI calculate nutrition when your recipe does not already include it.
+              </p>
+              <button
+                type="button"
+                disabled={!hasIngredients || nutritionLoadingState === 'loading'}
+                onClick={() =>
+                  estimateNutrition(form.ingredients, parseInt(form.servings, 10) || 1, form.title)
+                }
+                className="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {nutritionLoadingState === 'loading'
+                  ? 'Estimating…'
+                  : hasSavedNutrition
+                    ? 'Recalculate Nutrition with AI'
+                    : 'Calculate Missing Nutrition with AI'}
+              </button>
+              <NutritionEstimatePanel
+                estimate={nutritionEstimate}
+                loadingState={nutritionLoadingState}
+                error={nutritionError}
+                onAccept={handleAcceptNutritionEstimate}
+                onDismiss={clearNutritionEstimate}
+              />
+              {hasSavedNutrition && activeRecipeOverrides.nutritionalInfo && (
+                <div className="space-y-3">
+                  <p className="text-sm text-gray-600">
+                    AI nutrition values will be saved with this recipe unless you recalculate or dismiss them.
+                  </p>
+                  <NutritionFacts nutritionalInfo={activeRecipeOverrides.nutritionalInfo} />
+                </div>
+              )}
             </div>
           </CollapsibleSection>
 

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -11,9 +11,10 @@ import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
 import { useAIImageGeneration } from '../hooks/useAIImageGeneration'
 import { FIELD_LABELS } from '../constants/aiConstants'
 import { AIUndoButton } from './AIUndoButton'
-import { useNutritionEstimate } from '../hooks/useNutritionEstimate'
+import { mapEstimateToNutritionalInfo, useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
-import type { Ingredient } from '../../../types/nutrition'
+import type { Ingredient, Recipe } from '../../../types/nutrition'
+import NutritionFacts from '../../../components/NutritionFacts'
 
 interface RecipeFormLayoutProps {
   // Mode
@@ -81,6 +82,8 @@ interface RecipeFormLayoutProps {
   canUndoAI?: boolean
   onUndoLastAI?: () => void
   lastUndoableAIField?: string | null
+  nutritionalInfo?: Recipe['nutritionalInfo']
+  onNutritionalInfoChange?: (nutritionalInfo: Recipe['nutritionalInfo'] | undefined) => void
   normalizationStates?: Map<number, import('../hooks/useIngredientNormalization').NormalizationState>
   onApplyNormalization?: (index: number) => void
   onDismissNormalization?: (index: number) => void
@@ -141,6 +144,8 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   canUndoAI = false,
   onUndoLastAI,
   lastUndoableAIField,
+  nutritionalInfo,
+  onNutritionalInfoChange,
   normalizationStates,
   onApplyNormalization,
   onDismissNormalization,
@@ -187,6 +192,15 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   } = useNutritionEstimate()
 
   const hasIngredients = ingredients.some((i) => i.item.trim())
+  const hasSavedNutrition = Boolean(nutritionalInfo?.perServing)
+
+  const handleAcceptNutritionEstimate = useCallback(() => {
+    if (!onNutritionalInfoChange) return
+
+    acceptNutritionEstimate((estimate) => {
+      onNutritionalInfoChange(mapEstimateToNutritionalInfo(estimate))
+    })
+  }, [acceptNutritionEstimate, onNutritionalInfoChange])
 
 
   const handlePreviousStepClick = () => {
@@ -509,23 +523,35 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
           {/* Nutrition Estimate — shown on step 2 (Ingredients) */}
           {currentStep === 2 && (
             <div className="mt-4">
-              <button
-                type="button"
-                disabled={!hasIngredients || nutritionLoadingState === 'loading'}
+                <button
+                  type="button"
+                  disabled={!hasIngredients || nutritionLoadingState === 'loading'}
                 onClick={() =>
                   estimateNutrition(ingredients, parseInt(servings, 10) || 1, title)
                 }
                 className="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
-                {nutritionLoadingState === 'loading' ? 'Estimating…' : 'Recalculate Nutrition'}
+                {nutritionLoadingState === 'loading'
+                  ? 'Estimating…'
+                  : hasSavedNutrition
+                    ? 'Recalculate Nutrition with AI'
+                    : 'Calculate Missing Nutrition with AI'}
               </button>
               <NutritionEstimatePanel
                 estimate={nutritionEstimate}
                 loadingState={nutritionLoadingState}
                 error={nutritionError}
-                onAccept={() => acceptNutritionEstimate(() => {})}
+                onAccept={handleAcceptNutritionEstimate}
                 onDismiss={clearNutritionEstimate}
               />
+              {hasSavedNutrition && nutritionalInfo && (
+                <div className="mt-4 space-y-3">
+                  <p className="text-sm text-gray-600">
+                    AI nutrition values will be saved with this recipe unless you recalculate or dismiss them.
+                  </p>
+                  <NutritionFacts nutritionalInfo={nutritionalInfo} />
+                </div>
+              )}
             </div>
           )}
 

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -82,6 +82,27 @@ function makeProps(overrides: Partial<ComponentProps<typeof RecipeFormLayout>> =
 const renderWithRouter = (props: ComponentProps<typeof RecipeFormLayout>) =>
   render(<BrowserRouter><RecipeFormLayout {...props} /></BrowserRouter>)
 
+const mockNutritionEstimate = {
+  perServing: {
+    calories: { value: 220, unit: 'kcal', estimated: true },
+    protein: { value: 8, unit: 'g', estimated: true },
+    carbs: { value: 30, unit: 'g', estimated: true },
+    fat: { value: 6, unit: 'g', estimated: true },
+    fiber: { value: 4, unit: 'g', estimated: true },
+    warnings: [],
+    isPartial: false,
+  },
+  wholeRecipe: {
+    calories: { value: 880, unit: 'kcal', estimated: true },
+    protein: { value: 32, unit: 'g', estimated: true },
+    carbs: { value: 120, unit: 'g', estimated: true },
+    fat: { value: 24, unit: 'g', estimated: true },
+    fiber: { value: 16, unit: 'g', estimated: true },
+    warnings: [],
+    isPartial: false,
+  },
+}
+
 describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -191,5 +212,52 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
     )
+  })
+})
+
+describe('RecipeFormLayout — AI nutrition completion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('persists accepted nutrition estimates for saving', async () => {
+    mockPostWithAuth.mockResolvedValueOnce({ data: mockNutritionEstimate } as any)
+    const onNutritionalInfoChange = vi.fn()
+
+    renderWithRouter(makeProps({
+      currentStep: 2,
+      ingredients: [{ quantity: '1', unit: 'cup', item: 'flour' }],
+      onNutritionalInfoChange,
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: /Calculate Missing Nutrition with AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Accept/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Accept/i }))
+
+    expect(onNutritionalInfoChange).toHaveBeenCalledWith({
+      perServing: {
+        calories: 220,
+        protein: 8,
+        carbohydrates: 30,
+        fat: 6,
+        fiber: 4,
+      },
+      total: {
+        calories: 880,
+        protein: 32,
+        carbohydrates: 120,
+        fat: 24,
+        fiber: 16,
+      },
+    })
   })
 })

--- a/src/features/recipes/hooks/useNutritionEstimate.ts
+++ b/src/features/recipes/hooks/useNutritionEstimate.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { buildApiUrl } from '../../../utils/apiUtils'
 import { postWithAuth } from '../../../utils/authApi'
-import type { Ingredient } from '../../../types/nutrition'
+import type { Ingredient, NutritionalInfo, NutritionValues } from '../../../types/nutrition'
 
 export interface NutrientValue {
   value: number
@@ -23,6 +23,21 @@ export interface NutritionEstimateResponse {
   perServing: NutritionEstimate
   wholeRecipe: NutritionEstimate
 }
+
+const mapNutritionValues = (estimate: NutritionEstimate): NutritionValues => ({
+  calories: estimate.calories.value,
+  protein: estimate.protein.value,
+  carbohydrates: estimate.carbs.value,
+  fat: estimate.fat.value,
+  fiber: estimate.fiber.value,
+})
+
+export const mapEstimateToNutritionalInfo = (
+  estimate: NutritionEstimateResponse
+): NutritionalInfo => ({
+  perServing: mapNutritionValues(estimate.perServing),
+  total: mapNutritionValues(estimate.wholeRecipe),
+})
 
 export type NutritionLoadingState = 'idle' | 'loading' | 'success' | 'error'
 

--- a/src/features/recipes/hooks/useSimpleCreateSections.ts
+++ b/src/features/recipes/hooks/useSimpleCreateSections.ts
@@ -12,6 +12,7 @@ const SESSION_KEY = 'simple-create-sections'
 interface SectionState {
   timing: boolean
   serving: boolean
+  nutrition: boolean
   tags: boolean
   photo: boolean
 }
@@ -19,6 +20,7 @@ interface SectionState {
 const DEFAULT_SECTION_STATE: SectionState = {
   timing: false,
   serving: false,
+  nutrition: false,
   tags: false,
   photo: false,
 }
@@ -77,6 +79,11 @@ export function useSimpleCreateSections() {
       isOpen: open.serving,
       toggle: () => toggle('serving'),
       isFilled: (servings: string) => !!servings,
+    },
+    nutrition: {
+      isOpen: open.nutrition,
+      toggle: () => toggle('nutrition'),
+      isFilled: (hasNutrition: boolean) => hasNutrition,
     },
     tags: {
       isOpen: open.tags,


### PR DESCRIPTION
Summary: persist accepted AI nutrition estimates in recipe saves, expose AI nutrition calculation in quick entry and edit, and add quick-entry parity for AI-completed prep time, cook time, and servings. Validation: npm test -- --run src/features/recipes/SimpleCreateRecipe.test.tsx src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx && npm run build.