### PR TITLE
style: polish AI recipe authoring UI

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -397,9 +397,9 @@ describe('AI Enhancement', () => {
     setDefaultAuthMock()
   })
 
-  it('renders the "Review with AI" button', () => {
+  it('renders the "AI assist" button', () => {
     renderWithRouter(<SimpleCreateRecipe />)
-    expect(screen.getByRole('button', { name: /Review with AI/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /AI assist/i })).toBeInTheDocument()
   })
 
   it('does NOT show the AI suggestion panel before the button is clicked', () => {
@@ -407,14 +407,14 @@ describe('AI Enhancement', () => {
     expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
   })
 
-  it('shows the AI suggestion panel in loading state when "Review with AI" is clicked', async () => {
+  it('shows the AI suggestion panel in loading state when "AI assist" is clicked', async () => {
     const { postWithAuth } = await import('../../utils/authApi')
     // Keep the request pending so we can observe the loading state
     vi.mocked(postWithAuth).mockReturnValue(new Promise(() => {}))
 
     renderWithRouter(<SimpleCreateRecipe />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
@@ -520,7 +520,7 @@ describe('AI Undo Affordance', () => {
     } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     // Wait for the suggestion panel, then click its Apply button
     await waitFor(() => {
@@ -548,7 +548,7 @@ describe('AI Undo Affordance', () => {
     } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -397,9 +397,9 @@ describe('AI Enhancement', () => {
     setDefaultAuthMock()
   })
 
-  it('renders the "Enhance with AI" button', () => {
+  it('renders the "Review with AI" button', () => {
     renderWithRouter(<SimpleCreateRecipe />)
-    expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Review with AI/i })).toBeInTheDocument()
   })
 
   it('does NOT show the AI suggestion panel before the button is clicked', () => {
@@ -407,14 +407,14 @@ describe('AI Enhancement', () => {
     expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
   })
 
-  it('shows the AI suggestion panel in loading state when "Enhance with AI" is clicked', async () => {
+  it('shows the AI suggestion panel in loading state when "Review with AI" is clicked', async () => {
     const { postWithAuth } = await import('../../utils/authApi')
     // Keep the request pending so we can observe the loading state
     vi.mocked(postWithAuth).mockReturnValue(new Promise(() => {}))
 
     renderWithRouter(<SimpleCreateRecipe />)
 
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
@@ -520,7 +520,7 @@ describe('AI Undo Affordance', () => {
     } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     // Wait for the suggestion panel, then click its Apply button
     await waitFor(() => {
@@ -548,7 +548,7 @@ describe('AI Undo Affordance', () => {
     } as Awaited<ReturnType<typeof postWithAuth>>)
 
     renderWithRouter(<SimpleCreateRecipe />)
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -231,7 +231,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               type="button"
               onClick={handleEnhanceWithAI}
               disabled={suggestionStatus === 'loading'}
-              aria-label="Enhance recipe with AI"
+              aria-label={suggestionStatus === 'loading' ? 'Reviewing with AI' : 'Review with AI'}
               className={AI_BUTTON_CLASS}
             >
               {suggestionStatus === 'loading' ? (

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -14,6 +14,9 @@ import { AISuggestionPanel } from './components/AISuggestionPanel'
 import { FieldAIEnhanceButton } from './components/FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './components/FieldAISuggestionChip'
 import { AIUndoButton } from './components/AIUndoButton'
+import { AIBadge } from './components/AIBadge'
+import { AISpinnerIcon } from './components/AISpinnerIcon'
+import { AI_BUTTON_CLASS } from './components/aiStyles'
 import { FIELD_LABELS } from './constants/aiConstants'
 import { getRecipe } from '../../services/recipeStorageApi'
 import { useAuth } from '../auth/AuthContext'
@@ -229,14 +232,19 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               onClick={handleEnhanceWithAI}
               disabled={suggestionStatus === 'loading'}
               aria-label="Enhance recipe with AI"
-              className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className={AI_BUTTON_CLASS}
             >
               {suggestionStatus === 'loading' ? (
-                <span className="animate-spin">⏳</span>
+                <>
+                  <AISpinnerIcon />
+                  Reviewing...
+                </>
               ) : (
-                <span aria-hidden="true">✨</span>
+                <>
+                  <AIBadge />
+                  Review with AI
+                </>
               )}
-              Enhance with AI
             </button>
           </div>
         </div>

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -231,18 +231,17 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               type="button"
               onClick={handleEnhanceWithAI}
               disabled={suggestionStatus === 'loading'}
-              aria-label={suggestionStatus === 'loading' ? 'Reviewing with AI' : 'Review with AI'}
               className={AI_BUTTON_CLASS}
             >
               {suggestionStatus === 'loading' ? (
                 <>
                   <AISpinnerIcon />
-                  Reviewing...
+                  AI assist...
                 </>
               ) : (
                 <>
                   <AIBadge />
-                  Review with AI
+                  AI assist
                 </>
               )}
             </button>

--- a/src/features/recipes/components/AIBadge.tsx
+++ b/src/features/recipes/components/AIBadge.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface AIBadgeProps {
+  className?: string
+}
+
+export const AIBadge: React.FC<AIBadgeProps> = ({ className }) => (
+  <span
+    aria-hidden="true"
+    className={`inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 ${className ?? ''}`}
+  >
+    AI
+  </span>
+)

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -80,12 +80,11 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
         type="button"
         onClick={() => setIsExpanded(prev => !prev)}
         className="w-full flex items-center justify-between px-4 py-3 text-left rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        aria-label="AI Suggestions"
         aria-expanded={isExpanded}
       >
         <span className="flex items-center gap-3 text-sm">
           <AIBadge />
-          <span className="font-semibold text-gray-900">Suggestions</span>
+          <span className="font-semibold text-gray-900">AI Suggestions</span>
           {hasSuggestions && (
             <span className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-emerald-100 px-1.5 text-xs font-semibold text-emerald-700">
               {stepFilteredSuggestions.length}
@@ -108,7 +107,10 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
           {/* Error state */}
           {status === 'error' && (
             <div className={`flex items-center justify-between gap-3 text-sm text-rose-700 py-3 px-3 rounded-lg border border-rose-200 bg-rose-50`}>
-              <span>{error ?? 'Could not load suggestions.'}</span>
+              <span>
+                Could not load suggestions.
+                {error ? ` ${error}` : ''}
+              </span>
               {onRetry && (
                 <button
                   type="button"

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -2,6 +2,13 @@ import React from 'react'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { FIELD_LABELS, STEP_FIELDS } from '../constants/aiConstants'
 import { AISpinnerIcon } from './AISpinnerIcon'
+import { AIBadge } from './AIBadge'
+import {
+  AI_MUTED_PANEL_CLASS,
+  AI_PANEL_CLASS,
+  AI_PRIMARY_ACTION_CLASS,
+  AI_SECONDARY_ACTION_CLASS,
+} from './aiStyles'
 
 interface AISuggestionPanelProps {
   suggestions: FieldSuggestion[]
@@ -64,7 +71,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
 
   return (
     <div
-      className="mb-4 rounded-xl border border-amber-300 bg-amber-50 shadow-sm"
+      className={`mb-4 ${AI_PANEL_CLASS}`}
       role="region"
       aria-label="AI field suggestions"
     >
@@ -72,40 +79,41 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
       <button
         type="button"
         onClick={() => setIsExpanded(prev => !prev)}
-        className="w-full flex items-center justify-between px-4 py-3 text-left focus:outline-none focus:ring-2 focus:ring-amber-400 rounded-xl"
+        className="w-full flex items-center justify-between px-4 py-3 text-left rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        aria-label="AI Suggestions"
         aria-expanded={isExpanded}
       >
-        <span className="flex items-center gap-2 font-semibold text-amber-800 text-sm">
-          <span aria-hidden="true">✨</span>
-          AI Suggestions
+        <span className="flex items-center gap-3 text-sm">
+          <AIBadge />
+          <span className="font-semibold text-gray-900">Suggestions</span>
           {hasSuggestions && (
-            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-amber-500 text-white text-xs font-bold">
+            <span className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-emerald-100 px-1.5 text-xs font-semibold text-emerald-700">
               {stepFilteredSuggestions.length}
             </span>
           )}
         </span>
-        <span className="text-amber-600 text-xs">{isExpanded ? '▲ Hide' : '▼ Show'}</span>
+        <span className="text-xs text-gray-500">{isExpanded ? 'Hide' : 'Show'}</span>
       </button>
 
       {isExpanded && (
         <div className="px-4 pb-4">
           {/* Loading state */}
           {status === 'loading' && (
-            <div className="flex items-center gap-2 text-amber-700 text-sm py-2">
+            <div className={`flex items-center gap-2 text-sm text-gray-600 py-3 px-3 ${AI_MUTED_PANEL_CLASS}`}>
               <AISpinnerIcon />
-              Analysing your recipe for improvement suggestions…
+              Reviewing fields for suggestions...
             </div>
           )}
 
           {/* Error state */}
           {status === 'error' && (
-            <div className="flex items-center justify-between text-sm text-amber-800 py-2">
-              <span>⚠️ {error ?? 'Could not load suggestions.'}</span>
+            <div className={`flex items-center justify-between gap-3 text-sm text-rose-700 py-3 px-3 rounded-lg border border-rose-200 bg-rose-50`}>
+              <span>{error ?? 'Could not load suggestions.'}</span>
               {onRetry && (
                 <button
                   type="button"
                   onClick={onRetry}
-                  className="ml-3 px-3 py-1 text-xs rounded-md bg-amber-200 hover:bg-amber-300 text-amber-800 font-medium transition-colors"
+                  className={AI_SECONDARY_ACTION_CLASS}
                 >
                   Retry
                 </button>
@@ -124,25 +132,30 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                 return (
                   <li
                     key={suggestion.field}
-                    className="rounded-lg border border-amber-200 bg-white p-3 flex flex-col sm:flex-row sm:items-center gap-2"
+                    className="rounded-lg border border-gray-200 bg-gray-50/70 p-3 flex flex-col sm:flex-row sm:items-center gap-3"
                     role="listitem"
                     aria-label={`AI suggestion for ${label}`}
                   >
                     <div className="flex-1 min-w-0">
-                      <p className="text-xs font-semibold text-amber-700 mb-1">{label}</p>
+                      <div className="flex items-center gap-2 mb-1">
+                        <p className="text-xs font-semibold text-gray-700">{label}</p>
+                        <AIBadge />
+                      </div>
                       {currentValue && (
                         <p
-                          className="text-xs text-gray-500 break-words bg-gray-50 rounded px-2 py-1 border border-gray-100 mb-1 line-through"
+                          className="text-xs text-gray-500 break-words rounded-md px-2 py-1 border border-gray-200 bg-white mb-2"
                           aria-label={`Current value: ${currentValue}`}
                         >
-                          {currentValue}
+                          <span className="mr-1 font-medium text-gray-400">Current</span>
+                          <s>{currentValue}</s>
                         </p>
                       )}
                       <p
-                        className="text-sm text-gray-800 break-words bg-amber-50 rounded px-2 py-1 border border-amber-100"
+                        className="text-sm text-gray-800 break-words rounded-md px-2 py-1.5 border border-emerald-100 bg-emerald-50"
                         aria-label={`Suggested value: ${suggestion.suggestedValue}`}
                       >
-                        ✨ {suggestion.suggestedValue}
+                        <span className="mr-1 font-medium text-emerald-700">Suggested</span>
+                        {suggestion.suggestedValue}
                       </p>
                       {suggestion.reason && (
                         <p className="text-xs text-gray-500 mt-0.5 italic">{suggestion.reason}</p>
@@ -153,19 +166,19 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                         <button
                           type="button"
                           onClick={() => onApply(suggestion.field, setter, previousValue)}
-                          className="px-3 py-1.5 text-xs font-semibold rounded-md bg-amber-500 hover:bg-amber-600 text-white transition-colors"
+                          className={AI_PRIMARY_ACTION_CLASS}
                           aria-label={`Apply AI suggestion for ${label}`}
                         >
                           Apply
                         </button>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => onDismiss(suggestion.field)}
-                        className="px-3 py-1.5 text-xs font-medium rounded-md bg-gray-100 hover:bg-gray-200 text-gray-600 transition-colors"
-                        aria-label={`Dismiss AI suggestion for ${label}`}
-                      >
-                        Dismiss
+                        <button
+                          type="button"
+                          onClick={() => onDismiss(suggestion.field)}
+                          className={AI_SECONDARY_ACTION_CLASS}
+                          aria-label={`Dismiss AI suggestion for ${label}`}
+                        >
+                          Dismiss
                       </button>
                     </div>
                   </li>

--- a/src/features/recipes/components/AIUndoButton.tsx
+++ b/src/features/recipes/components/AIUndoButton.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react'
+import { AIBadge } from './AIBadge'
+import { AI_BUTTON_COMPACT_CLASS } from './aiStyles'
 
 interface AIUndoButtonProps {
   lastField: string | null
@@ -29,9 +31,11 @@ export const AIUndoButton: React.FC<AIUndoButtonProps> = ({ lastField, onUndo, f
       type="button"
       onClick={onUndo}
       aria-label={`Undo: ${label}`}
-      className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 transition-colors"
+      className={AI_BUTTON_COMPACT_CLASS}
     >
-      <span aria-hidden="true">↩</span> Undo: {label}
+      <AIBadge />
+      <span aria-hidden="true" className="text-gray-400">/</span>
+      <span className="text-gray-600">Undo {label}</span>
     </button>
   )
 }

--- a/src/features/recipes/components/FieldAIEnhanceButton.tsx
+++ b/src/features/recipes/components/FieldAIEnhanceButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { SuggestionStatus } from '../hooks/useAISuggestions'
 import { AISpinnerIcon } from './AISpinnerIcon'
+import { AI_ICON_BUTTON_CLASS } from './aiStyles'
 
 export interface FieldAIEnhanceButtonProps {
   field: string
@@ -30,12 +31,12 @@ export const FieldAIEnhanceButton: React.FC<FieldAIEnhanceButtonProps> = ({
       aria-label={label}
       title={title}
       data-field={field}
-      className={`inline-flex items-center justify-center w-7 h-7 rounded-md text-amber-400 hover:text-amber-500 hover:bg-amber-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${className ?? ''}`}
+      className={`${AI_ICON_BUTTON_CLASS} ${className ?? ''}`}
     >
       {isLoading ? (
         <AISpinnerIcon className="w-3.5 h-3.5" />
       ) : (
-        <span aria-hidden="true">✨</span>
+        <span aria-hidden="true">AI</span>
       )}
     </button>
   )

--- a/src/features/recipes/components/FieldAISuggestionChip.tsx
+++ b/src/features/recipes/components/FieldAISuggestionChip.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { AIBadge } from './AIBadge'
+import { AI_MUTED_PANEL_CLASS, AI_PRIMARY_ACTION_CLASS, AI_SECONDARY_ACTION_CLASS } from './aiStyles'
 
 export interface FieldAISuggestionChipProps {
   field: string
@@ -15,28 +17,28 @@ export const FieldAISuggestionChip: React.FC<FieldAISuggestionChipProps> = ({
   onDismiss,
 }) => {
   return (
-    <div className="mt-1.5 px-3 py-2 rounded-lg border border-amber-200 bg-amber-50 text-sm flex items-start gap-3">
-      <span className="text-amber-500 mt-0.5 shrink-0" aria-hidden="true">✨</span>
+    <div className={`mt-2 px-3 py-3 text-sm flex items-start gap-3 ${AI_MUTED_PANEL_CLASS}`}>
+      <AIBadge className="mt-0.5 shrink-0" />
       <div className="flex-1 min-w-0">
         {currentValue && (
-          <p className="text-gray-400 text-xs mb-0.5">
+          <p className="text-gray-500 text-xs mb-1">
             <s>{currentValue}</s>
           </p>
         )}
-        <p className="text-gray-800">{suggestion}</p>
+        <p className="text-gray-800 leading-5">{suggestion}</p>
       </div>
       <div className="flex items-center gap-1.5 shrink-0">
         <button
           type="button"
           onClick={onApply}
-          className="px-2 py-1 text-xs font-medium rounded-md bg-amber-500 text-white hover:bg-amber-600 transition-colors"
+          className={AI_PRIMARY_ACTION_CLASS}
         >
           Apply
         </button>
         <button
           type="button"
           onClick={onDismiss}
-          className="px-2 py-1 text-xs font-medium rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+          className={AI_SECONDARY_ACTION_CLASS}
         >
           Dismiss
         </button>

--- a/src/features/recipes/components/NutritionEstimatePanel.tsx
+++ b/src/features/recipes/components/NutritionEstimatePanel.tsx
@@ -27,11 +27,11 @@ function NutrientRow({
   if (!perServing || !wholeRecipe) return null
   return (
     <tr>
-      <td className="py-1 pr-4 font-medium text-gray-700 dark:text-gray-300">{label}</td>
-      <td className="py-1 pr-4 text-right text-gray-900 dark:text-gray-100">
+      <td className="py-1 pr-4 font-medium text-gray-700">{label}</td>
+      <td className="py-1 pr-4 text-right text-gray-900">
         {formatNutrient(perServing.value, perServing.unit, perServing.estimated)}
       </td>
-      <td className="py-1 text-right text-gray-900 dark:text-gray-100">
+      <td className="py-1 text-right text-gray-900">
         {formatNutrient(wholeRecipe.value, wholeRecipe.unit, wholeRecipe.estimated)}
       </td>
     </tr>
@@ -49,9 +49,9 @@ function NutritionTable({
     <table className="w-full text-sm mt-2">
       <thead>
         <tr>
-          <th className="text-left py-1 pr-4 text-gray-500 dark:text-gray-400 font-normal">Nutrient</th>
-          <th className="text-right py-1 pr-4 text-gray-500 dark:text-gray-400 font-normal">Per Serving</th>
-          <th className="text-right py-1 text-gray-500 dark:text-gray-400 font-normal">Whole Recipe</th>
+          <th className="text-left py-1 pr-4 text-gray-500 font-normal">Nutrient</th>
+          <th className="text-right py-1 pr-4 text-gray-500 font-normal">Per Serving</th>
+          <th className="text-right py-1 text-gray-500 font-normal">Whole Recipe</th>
         </tr>
       </thead>
       <tbody>
@@ -111,6 +111,7 @@ export const NutritionEstimatePanel: React.FC<NutritionEstimatePanelProps> = ({
         <AIBadge />
         <h4 className="text-sm font-semibold text-gray-900">
           Nutrition estimate
+          <span className="sr-only">, AI generated</span>
         </h4>
         {isPartial && (
           <span className="text-xs font-medium text-amber-700">(partial)</span>

--- a/src/features/recipes/components/NutritionEstimatePanel.tsx
+++ b/src/features/recipes/components/NutritionEstimatePanel.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import type { NutritionEstimate, NutritionEstimateResponse, NutritionLoadingState } from '../hooks/useNutritionEstimate'
+import { AIBadge } from './AIBadge'
+import { AI_MUTED_PANEL_CLASS, AI_PRIMARY_ACTION_CLASS, AI_SECONDARY_ACTION_CLASS } from './aiStyles'
 
 interface NutritionEstimatePanelProps {
   estimate: NutritionEstimateResponse | null
@@ -72,22 +74,25 @@ export const NutritionEstimatePanel: React.FC<NutritionEstimatePanelProps> = ({
 }) => {
   if (loadingState === 'loading') {
     return (
-      <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-700">
-        <p className="text-sm text-blue-600 dark:text-blue-400">Estimating nutrition…</p>
+      <div className={`mt-3 p-3 ${AI_MUTED_PANEL_CLASS}`}>
+        <div className="flex items-center gap-2">
+          <AIBadge />
+          <p className="text-sm text-gray-700">Estimating nutrition...</p>
+        </div>
       </div>
     )
   }
 
   if (loadingState === 'error') {
     return (
-      <div className="mt-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg border border-yellow-200 dark:border-yellow-700">
-        <p className="text-sm text-yellow-700 dark:text-yellow-400">
+      <div className="mt-3 p-3 rounded-lg border border-rose-200 bg-rose-50">
+        <p className="text-sm text-rose-700">
           {error ?? 'Could not estimate nutrition.'} Please try again.
         </p>
         <button
           type="button"
           onClick={onDismiss}
-          className="mt-1 text-xs text-yellow-600 dark:text-yellow-400 underline"
+          className="mt-2 text-xs font-medium text-rose-700 underline underline-offset-2"
         >
           Dismiss
         </button>
@@ -101,18 +106,21 @@ export const NutritionEstimatePanel: React.FC<NutritionEstimatePanelProps> = ({
   const isPartial = estimate.perServing.isPartial || estimate.wholeRecipe.isPartial
 
   return (
-    <div className="mt-3 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-700">
-      <h4 className="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">
-        Nutrition Estimate
+    <div className="mt-3 p-4 rounded-lg border border-gray-200 bg-white">
+      <div className="flex items-center gap-2 mb-2">
+        <AIBadge />
+        <h4 className="text-sm font-semibold text-gray-900">
+          Nutrition estimate
+        </h4>
         {isPartial && (
-          <span className="ml-2 text-xs font-normal text-yellow-600 dark:text-yellow-400">(partial)</span>
+          <span className="text-xs font-medium text-amber-700">(partial)</span>
         )}
-      </h4>
+      </div>
 
       <NutritionTable perServing={estimate.perServing} wholeRecipe={estimate.wholeRecipe} />
 
       {(isPartial || warnings.length > 0) && (
-        <ul className="mt-2 text-xs text-yellow-700 dark:text-yellow-400 list-disc list-inside space-y-0.5">
+        <ul className="mt-3 text-xs text-amber-700 list-disc list-inside space-y-0.5">
           {warnings.map((w, i) => (
             <li key={i}>{w}</li>
           ))}
@@ -126,14 +134,14 @@ export const NutritionEstimatePanel: React.FC<NutritionEstimatePanelProps> = ({
         <button
           type="button"
           onClick={onAccept}
-          className="px-3 py-1 text-xs font-medium bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+          className={AI_PRIMARY_ACTION_CLASS}
         >
           Accept
         </button>
         <button
           type="button"
           onClick={onDismiss}
-          className="px-3 py-1 text-xs font-medium bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+          className={AI_SECONDARY_ACTION_CLASS}
         >
           Dismiss
         </button>

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -11,8 +11,10 @@ import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
 import { useAIImageGeneration } from '../hooks/useAIImageGeneration'
 import { FIELD_LABELS } from '../constants/aiConstants'
 import { AIUndoButton } from './AIUndoButton'
+import { AIBadge } from './AIBadge'
 import { mapEstimateToNutritionalInfo, useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
+import { AI_BUTTON_CLASS } from './aiStyles'
 import type { Ingredient, Recipe } from '../../../types/nutrition'
 import NutritionFacts from '../../../components/NutritionFacts'
 
@@ -398,14 +400,19 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 onClick={handleEnhanceWithAI}
                 disabled={suggestionStatus === 'loading'}
                 aria-label="Enhance recipe with AI"
-                className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className={AI_BUTTON_CLASS}
               >
                 {suggestionStatus === 'loading' ? (
-                  <AISpinnerIcon />
+                  <>
+                    <AISpinnerIcon />
+                    Reviewing...
+                  </>
                 ) : (
-                  <span aria-hidden="true">✨</span>
+                  <>
+                    <AIBadge />
+                    Review with AI
+                  </>
                 )}
-                Enhance with AI
               </button>
               )}
             </div>

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -399,7 +399,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 type="button"
                 onClick={handleEnhanceWithAI}
                 disabled={suggestionStatus === 'loading'}
-                aria-label="Enhance recipe with AI"
+                aria-label={suggestionStatus === 'loading' ? 'Reviewing with AI' : 'Review with AI'}
                 className={AI_BUTTON_CLASS}
               >
                 {suggestionStatus === 'loading' ? (

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -399,18 +399,17 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 type="button"
                 onClick={handleEnhanceWithAI}
                 disabled={suggestionStatus === 'loading'}
-                aria-label={suggestionStatus === 'loading' ? 'Reviewing with AI' : 'Review with AI'}
                 className={AI_BUTTON_CLASS}
               >
                 {suggestionStatus === 'loading' ? (
                   <>
                     <AISpinnerIcon />
-                    Reviewing...
+                    AI assist...
                   </>
                 ) : (
                   <>
                     <AIBadge />
-                    Review with AI
+                    AI assist
                   </>
                 )}
               </button>

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -10,7 +10,7 @@ import { FieldAISuggestionChip } from './FieldAISuggestionChip'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { AISpinnerIcon } from './AISpinnerIcon'
 import { AIBadge } from './AIBadge'
-import { AI_BUTTON_CLASS, AI_BUTTON_COMPACT_CLASS, AI_ICON_BUTTON_CLASS } from './aiStyles'
+import { AI_BUTTON_CLASS, AI_BUTTON_COMPACT_CLASS, AI_STEP_ACTION_BUTTON_CLASS } from './aiStyles'
 
 
 interface RecipeFormStepsProps {
@@ -292,6 +292,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   type="button"
                   onClick={() => onGenerateAIImage(recipeName.trim(), description || undefined)}
                   disabled={!recipeName.trim() || generatingAIImage}
+                  aria-label={imagePreview ? 'Regenerate image with AI' : 'Generate image with AI'}
                   className={`mt-3 ${AI_BUTTON_CLASS}`}
                 >
                   {generatingAIImage ? (
@@ -422,7 +423,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
             disabled={instructionRefinementLoading === 'loading'}
             aria-label={`Refine step ${index + 1} with AI`}
             title="Refine this step with AI"
-            className={`w-10 ${AI_ICON_BUTTON_CLASS}`}
+            className={AI_STEP_ACTION_BUTTON_CLASS}
           >
             <span aria-hidden="true">AI</span>
           </button>

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -9,6 +9,8 @@ import { FieldAIEnhanceButton } from './FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './FieldAISuggestionChip'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { AISpinnerIcon } from './AISpinnerIcon'
+import { AIBadge } from './AIBadge'
+import { AI_BUTTON_CLASS, AI_BUTTON_COMPACT_CLASS, AI_ICON_BUTTON_CLASS } from './aiStyles'
 
 
 interface RecipeFormStepsProps {
@@ -290,7 +292,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   type="button"
                   onClick={() => onGenerateAIImage(recipeName.trim(), description || undefined)}
                   disabled={!recipeName.trim() || generatingAIImage}
-                  className="mt-3 flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className={`mt-3 ${AI_BUTTON_CLASS}`}
                 >
                   {generatingAIImage ? (
                     <>
@@ -299,7 +301,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     </>
                   ) : (
                     <>
-                      <span aria-hidden="true">✨</span>
+                      <AIBadge />
                       {imagePreview ? 'Regenerate image' : 'Generate image'}
                     </>
                   )}
@@ -356,12 +358,12 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     onClick={onRefineAllInstructions}
                     disabled={instructionRefinementLoading === 'loading' || !instructions.some(i => i.trim())}
                     aria-label="Refine all instructions with AI"
-                    className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-amber-300 text-amber-700 bg-amber-50 hover:bg-amber-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    className={AI_BUTTON_COMPACT_CLASS}
                   >
                     {instructionRefinementLoading === 'loading' ? (
                       <AISpinnerIcon />
                     ) : (
-                      <span aria-hidden="true">✨</span>
+                      <AIBadge />
                     )}
                     Refine all
                   </button>
@@ -420,9 +422,9 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
             disabled={instructionRefinementLoading === 'loading'}
             aria-label={`Refine step ${index + 1} with AI`}
             title="Refine this step with AI"
-            className="w-10 h-10 flex items-center justify-center text-amber-500 hover:text-amber-700 hover:bg-amber-50 rounded-lg transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className={`w-10 ${AI_ICON_BUTTON_CLASS}`}
           >
-            ✨
+            <span aria-hidden="true">AI</span>
           </button>
         )}
         {instructions.length > 1 && (

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -150,9 +150,11 @@ describe('AISuggestionPanel', () => {
         onApply={vi.fn()}
         onDismiss={vi.fn()}
         fieldSetters={{ description: vi.fn() }}
+        currentValues={{ description: 'Existing description' }}
       />
     )
-    expect(screen.getAllByText('AI').length).toBeGreaterThan(0)
+    expect(screen.getByText(/AI Suggestions/i)).toBeInTheDocument()
+    expect(screen.getByText('Current')).toBeInTheDocument()
     expect(screen.getByText('Suggested')).toBeInTheDocument()
   })
 

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -34,7 +34,7 @@ describe('AISuggestionPanel', () => {
         fieldSetters={{}}
       />
     )
-    expect(screen.getByText(/analysing your recipe/i)).toBeInTheDocument()
+    expect(screen.getByText(/reviewing fields for suggestions/i)).toBeInTheDocument()
   })
 
   it('shows error message when status is error', () => {
@@ -141,7 +141,7 @@ describe('AISuggestionPanel', () => {
     expect(onDismiss).toHaveBeenCalledWith('description')
   })
 
-  it('shows the ✨ icon to visually distinguish AI suggestions', () => {
+  it('shows AI labels that distinguish current and suggested values', () => {
     render(
       <AISuggestionPanel
         suggestions={[mockSuggestions[0]]}
@@ -152,9 +152,8 @@ describe('AISuggestionPanel', () => {
         fieldSetters={{ description: vi.fn() }}
       />
     )
-    // The panel header has ✨ and each card value also has ✨
-    const sparkles = screen.getAllByText(/✨/)
-    expect(sparkles.length).toBeGreaterThan(0)
+    expect(screen.getAllByText('AI').length).toBeGreaterThan(0)
+    expect(screen.getByText('Suggested')).toBeInTheDocument()
   })
 
   it('collapses and expands on header button click', () => {

--- a/src/features/recipes/components/__tests__/FieldAIEnhanceButton.test.tsx
+++ b/src/features/recipes/components/__tests__/FieldAIEnhanceButton.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { FieldAIEnhanceButton } from '../FieldAIEnhanceButton'
 
 describe('FieldAIEnhanceButton', () => {
-  it('renders a sparkle icon button', () => {
+  it('renders a compact AI button', () => {
     render(
       <FieldAIEnhanceButton
         field="recipeName"
@@ -13,7 +13,7 @@ describe('FieldAIEnhanceButton', () => {
       />
     )
     expect(screen.getByRole('button')).toBeInTheDocument()
-    expect(screen.getByText('✨')).toBeInTheDocument()
+    expect(screen.getByText('AI')).toBeInTheDocument()
   })
 
   it('has aria-label "Complete with AI" when currentValue is empty', () => {

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -118,21 +118,21 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     expect(mockPostWithAuth).not.toHaveBeenCalled()
   })
 
-  it('renders the "Enhance with AI" button on non-preview steps', () => {
+  it('renders the "Review with AI" button on non-preview steps', () => {
     renderWithRouter(makeProps())
-    expect(screen.getByRole('button', { name: /Enhance recipe with AI/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Review with AI/i })).toBeInTheDocument()
   })
 
-  it('does NOT render the "Enhance with AI" button on step 5 (preview)', () => {
+  it('does NOT render the "Review with AI" button on step 5 (preview)', () => {
     renderWithRouter(makeProps({ currentStep: 5 }))
-    expect(screen.queryByRole('button', { name: /Enhance recipe with AI/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Review with AI/i })).not.toBeInTheDocument()
   })
 
-  it('calls AI suggestions API when "Enhance with AI" is clicked', async () => {
+  it('calls AI suggestions API when "Review with AI" is clicked', async () => {
     mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     await waitFor(() => expect(mockPostWithAuth).toHaveBeenCalledOnce())
     expect(mockPostWithAuth).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     // Panel is hidden before click
     expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     await waitFor(() =>
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
@@ -166,7 +166,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     mockPostWithAuth.mockImplementationOnce(() => new Promise(r => { resolvePost = r }))
 
     renderWithRouter(makeProps())
-    const btn = screen.getByRole('button', { name: /Enhance recipe with AI/i })
+    const btn = screen.getByRole('button', { name: /Review with AI/i })
     fireEvent.click(btn)
 
     await waitFor(() => expect(btn).toBeDisabled())
@@ -202,7 +202,7 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
     } as any)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
-    fireEvent.click(screen.getByRole('button', { name: /Enhance recipe with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Apply AI suggestion for Description/i })).toBeInTheDocument()

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -118,21 +118,21 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     expect(mockPostWithAuth).not.toHaveBeenCalled()
   })
 
-  it('renders the "Review with AI" button on non-preview steps', () => {
+  it('renders the "AI assist" button on non-preview steps', () => {
     renderWithRouter(makeProps())
-    expect(screen.getByRole('button', { name: /Review with AI/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /AI assist/i })).toBeInTheDocument()
   })
 
-  it('does NOT render the "Review with AI" button on step 5 (preview)', () => {
+  it('does NOT render the "AI assist" button on step 5 (preview)', () => {
     renderWithRouter(makeProps({ currentStep: 5 }))
-    expect(screen.queryByRole('button', { name: /Review with AI/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /AI assist/i })).not.toBeInTheDocument()
   })
 
-  it('calls AI suggestions API when "Review with AI" is clicked', async () => {
+  it('calls AI suggestions API when "AI assist" is clicked', async () => {
     mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     await waitFor(() => expect(mockPostWithAuth).toHaveBeenCalledOnce())
     expect(mockPostWithAuth).toHaveBeenCalledWith(
@@ -154,7 +154,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     // Panel is hidden before click
     expect(screen.queryByRole('region', { name: /AI field suggestions/i })).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     await waitFor(() =>
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
@@ -166,7 +166,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     mockPostWithAuth.mockImplementationOnce(() => new Promise(r => { resolvePost = r }))
 
     renderWithRouter(makeProps())
-    const btn = screen.getByRole('button', { name: /Review with AI/i })
+    const btn = screen.getByRole('button', { name: /^AI assist$/i })
     fireEvent.click(btn)
 
     await waitFor(() => expect(btn).toBeDisabled())
@@ -202,7 +202,7 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
     } as any)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
-    fireEvent.click(screen.getByRole('button', { name: /Review with AI/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
 
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Apply AI suggestion for Description/i })).toBeInTheDocument()

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -283,7 +283,7 @@ describe('RecipeFormSteps — AI image generation (issue #41)', () => {
         })}
       />
     )
-    const btn = screen.getByRole('button', { name: /Generating/i })
+    const btn = screen.getByRole('button', { name: /Generate image with AI/i })
     expect(btn).toBeDisabled()
     expect(btn).toHaveTextContent('Generating...')
   })

--- a/src/features/recipes/components/aiStyles.ts
+++ b/src/features/recipes/components/aiStyles.ts
@@ -1,0 +1,13 @@
+export const AI_BUTTON_CLASS = 'inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
+
+export const AI_BUTTON_COMPACT_CLASS = 'inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
+
+export const AI_ICON_BUTTON_CLASS = 'inline-flex h-7 items-center justify-center rounded-full border border-gray-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500 shadow-sm transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
+
+export const AI_PANEL_CLASS = 'rounded-xl border border-gray-200 bg-white shadow-sm'
+
+export const AI_MUTED_PANEL_CLASS = 'rounded-lg border border-emerald-100 bg-emerald-50/60'
+
+export const AI_PRIMARY_ACTION_CLASS = 'px-3 py-1.5 text-xs font-semibold rounded-md bg-emerald-600 text-white transition-colors hover:bg-emerald-700'
+
+export const AI_SECONDARY_ACTION_CLASS = 'px-3 py-1.5 text-xs font-medium rounded-md border border-gray-200 bg-white text-gray-600 transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-800'

--- a/src/features/recipes/components/aiStyles.ts
+++ b/src/features/recipes/components/aiStyles.ts
@@ -4,6 +4,8 @@ export const AI_BUTTON_COMPACT_CLASS = 'inline-flex items-center gap-2 rounded-m
 
 export const AI_ICON_BUTTON_CLASS = 'inline-flex h-7 items-center justify-center rounded-full border border-gray-200 bg-white px-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500 shadow-sm transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
 
+export const AI_STEP_ACTION_BUTTON_CLASS = 'inline-flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-white text-xs font-semibold uppercase tracking-[0.14em] text-gray-500 transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:cursor-not-allowed disabled:opacity-50'
+
 export const AI_PANEL_CLASS = 'rounded-xl border border-gray-200 bg-white shadow-sm'
 
 export const AI_MUTED_PANEL_CLASS = 'rounded-lg border border-emerald-100 bg-emerald-50/60'

--- a/tests/ai-authoring.spec.ts
+++ b/tests/ai-authoring.spec.ts
@@ -85,13 +85,13 @@ async function mockNormalizeIngredients(page: Page) {
   })
 }
 
-/** Fill the recipe title on step 1, then click the Enhance with AI button to trigger suggestions. */
+/** Fill the recipe title on step 1, then click the AI assist button to trigger suggestions. */
 async function fillRecipeTitle(page: Page, title = 'Test Recipe') {
   await page.goto('/dashboard/create')
   await page.waitForLoadState('networkidle')
   await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill(title)
   // AI enhancement is now on-demand — click the button to fetch suggestions
-  await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
+  await page.getByRole('button', { name: /^AI assist$/i }).click()
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -227,8 +227,8 @@ test.describe('AI-assisted authoring — field suggestions', () => {
     await expect(page.getByText(/Step 1 of 5/i)).toBeVisible()
 
     await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill('My Test Cake')
-    // Click Enhance with AI to request suggestions (on-demand trigger)
-    await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
+    // Click AI assist to request suggestions (on-demand trigger)
+    await page.getByRole('button', { name: /^AI assist$/i }).click()
     // Wait for the AI suggestion panel to load
     const panel = page.getByRole('region', { name: /AI field suggestions/i })
     await expect(panel).toBeVisible({ timeout: 8000 })
@@ -280,9 +280,9 @@ test.describe('AI-assisted authoring — edit flow', () => {
     await page.goto('/dashboard/create')
     await page.waitForLoadState('networkidle')
 
-    // Fill a title and click Enhance with AI to trigger suggestion fetch
+    // Fill a title and click AI assist to trigger suggestion fetch
     await page.getByPlaceholder(/Grandma's Chocolate Chip Cookies/i).fill('Existing Cake')
-    await page.getByRole('button', { name: /Enhance recipe with AI/i }).click()
+    await page.getByRole('button', { name: /^AI assist$/i }).click()
     const panel = page.getByRole('region', { name: /AI field suggestions/i })
     await expect(panel).toBeVisible({ timeout: 8000 })
 


### PR DESCRIPTION
Summary: tone down the AI visual treatment in recipe create/edit so it feels native to the existing form UI. This swaps loud amber/emoji affordances for subtle AI badges, quieter action buttons, and cleaner suggestion/nutrition panels without changing the underlying AI flows. Validation: npm test -- --run src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx src/features/recipes/components/__tests__/FieldAIEnhanceButton.test.tsx src/features/recipes/components/__tests__/AIUndoButton.test.tsx src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx src/features/recipes/SimpleCreateRecipe.test.tsx && npm run build. Note: npm run lint reports existing baseline issues in unrelated files already present on main, so this PR is intentionally scoped to the AI UI polish.