### PR TITLE
Fix dark mode inconsistencies across key screens

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -209,7 +209,7 @@ export const Dashboard: React.FC = () => {
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: 0.4 + index * 0.1, duration: 0.3 }}
-              className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+              className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 transition-colors duration-300"
             >
               <StatsSkeleton />
             </motion.div>
@@ -221,14 +221,14 @@ export const Dashboard: React.FC = () => {
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: 0.4 + index * 0.1, duration: 0.3 }}
-              className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+              className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 transition-colors duration-300"
             >
               <div className="flex items-center justify-between">
                 <div>
-                  <p className="text-sm font-medium text-gray-600">{stat.label}</p>
-                  <p className="text-3xl font-bold text-gray-900">{stat.value}</p>
+                  <p className="text-sm font-medium text-gray-600 dark:text-gray-300">{stat.label}</p>
+                  <p className="text-3xl font-bold text-gray-900 dark:text-gray-100">{stat.value}</p>
                 </div>
-                <div className={`p-3 rounded-full bg-gray-50 ${stat.color}`}>
+                <div className={`p-3 rounded-full bg-gray-50 dark:bg-slate-700/60 ${stat.color}`}>
                   {stat.icon}
                 </div>
               </div>
@@ -242,9 +242,9 @@ export const Dashboard: React.FC = () => {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.5, duration: 0.5 }}
-        className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+        className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 transition-colors duration-300"
       >
-        <h2 className="text-xl font-semibold text-gray-900 mb-4">Quick Actions</h2>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">Quick Actions</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {quickActions.map((action, index) => (
             <motion.button
@@ -277,7 +277,7 @@ export const Dashboard: React.FC = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.7, duration: 0.5 }}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+          className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 transition-colors duration-300"
         >
           <RecentRecipesSkeleton />
         </motion.div>
@@ -286,13 +286,13 @@ export const Dashboard: React.FC = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.7, duration: 0.5 }}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+          className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 transition-colors duration-300"
         >
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold text-gray-900">Recent Recipes</h2>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Recent Recipes</h2>
             <button
               onClick={() => navigate('/dashboard/recipes')}
-              className="text-sm text-emerald-600 hover:text-emerald-700 font-medium"
+              className="text-sm text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 font-medium"
             >
               View all →
             </button>
@@ -318,20 +318,20 @@ export const Dashboard: React.FC = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.8, duration: 0.5 }}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center"
+          className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-8 text-center transition-colors duration-300"
         >
           <motion.div
             initial={{ scale: 0.8, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             transition={{ delay: 1, duration: 0.5 }}
-            className="mx-auto w-24 h-24 bg-gradient-to-br from-emerald-100 to-teal-100 rounded-full flex items-center justify-center mb-6"
+            className="mx-auto w-24 h-24 bg-gradient-to-br from-emerald-100 to-teal-100 dark:from-emerald-900/40 dark:to-teal-900/40 rounded-full flex items-center justify-center mb-6"
           >
             <svg className="w-12 h-12 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
             </svg>
           </motion.div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">Start Your Recipe Journey</h2>
-          <p className="text-gray-600 mb-6 max-w-md mx-auto">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Start Your Recipe Journey</h2>
+          <p className="text-gray-600 dark:text-gray-300 mb-6 max-w-md mx-auto">
             Create your first recipe manually or let AI help you generate delicious ideas. Your culinary adventure awaits!
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/components/Layout/DashboardLayout.tsx
+++ b/src/components/Layout/DashboardLayout.tsx
@@ -123,7 +123,7 @@ export const DashboardLayout: React.FC = () => {
             className="fixed inset-y-4 left-4 z-50 w-64 h-[calc(100vh-2rem)] bg-white/95 dark:bg-slate-800/95 backdrop-blur-xl border border-gray-200 dark:border-slate-700 rounded-3xl shadow-2xl transition-colors duration-300 overflow-hidden flex flex-col"
           >
           {/* Logo/Brand */}
-          <div className="flex items-center justify-between px-6 py-5 border-b border-gray-200">
+          <div className="flex items-center justify-between px-6 py-5 border-b border-gray-200 dark:border-slate-700">
             <motion.div
               className="flex items-center space-x-3"
               initial={{ opacity: 0, y: -10 }}
@@ -151,7 +151,7 @@ export const DashboardLayout: React.FC = () => {
             </motion.div>
             <motion.button
               onClick={() => setIsSidebarOpen(false)}
-              className="lg:hidden text-gray-500 hover:text-gray-700 p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              className="lg:hidden text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
               whileHover={{ scale: 1.1, rotate: 90 }}
               whileTap={{ scale: 0.9 }}
               transition={{ duration: 0.2 }}
@@ -206,7 +206,7 @@ export const DashboardLayout: React.FC = () => {
                       <motion.span
                         initial={{ scale: 0 }}
                         animate={{ scale: 1 }}
-                        className="px-2 py-1 text-xs font-semibold text-emerald-700 bg-emerald-100 rounded-full"
+                        className="px-2 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300 bg-emerald-100 dark:bg-emerald-900/30 rounded-full"
                       >
                         {item.badge}
                       </motion.span>
@@ -243,7 +243,7 @@ export const DashboardLayout: React.FC = () => {
             </div>
             <motion.button
               onClick={handleLogout}
-              className="w-full flex items-center justify-center space-x-2 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+              className="w-full flex items-center justify-center space-x-2 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-lg transition-colors"
               whileHover={{ scale: 1.02, backgroundColor: 'rgba(239, 68, 68, 0.1)' }}
               whileTap={{ scale: 0.98 }}
               transition={{ duration: 0.2 }}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -99,8 +99,8 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({ recipe, onView, onDelete
             </div>
           </div>
         ) : (
-          <div className="h-40 sm:h-48 bg-gradient-to-br from-gray-100 to-gray-200 flex items-center justify-center">
-            <svg className="w-12 h-12 sm:w-16 sm:h-16 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="h-40 sm:h-48 bg-gradient-to-br from-gray-100 to-gray-200 dark:from-slate-800 dark:to-slate-700 flex items-center justify-center">
+            <svg className="w-12 h-12 sm:w-16 sm:h-16 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
           </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -9,8 +9,10 @@ export const ThemeToggle: React.FC = () => {
     <motion.button
       type="button"
       onClick={toggleTheme}
-      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 overflow-hidden ${
-        theme === 'dark' ? 'bg-slate-700' : 'bg-emerald-100'
+      className={`relative inline-flex h-8 w-14 items-center rounded-full border overflow-hidden transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-gray-50 dark:focus:ring-offset-slate-900 ${
+        theme === 'dark'
+          ? 'border-slate-600 bg-slate-700'
+          : 'border-emerald-200 bg-emerald-100'
       }`}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}

--- a/src/features/auth/components/AuthBrandHeader.tsx
+++ b/src/features/auth/components/AuthBrandHeader.tsx
@@ -26,7 +26,7 @@ export const AuthBrandHeader: React.FC<AuthBrandHeaderProps> = ({ title, subtitl
         <div className="absolute -top-1 -right-1 w-3 h-3 bg-amber-400 rounded-full"></div>
       </motion.div>
       <motion.h1 
-        className="text-3xl font-bold text-gray-800 mb-1"
+        className="text-3xl font-bold text-gray-800 dark:text-gray-100 mb-1"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.4 }}
@@ -34,7 +34,7 @@ export const AuthBrandHeader: React.FC<AuthBrandHeaderProps> = ({ title, subtitl
         CookFlow
       </motion.h1>
       <motion.p 
-        className="text-sm text-gray-500 mb-4"
+        className="text-sm text-gray-500 dark:text-gray-400 mb-4"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.5 }}
@@ -42,7 +42,7 @@ export const AuthBrandHeader: React.FC<AuthBrandHeaderProps> = ({ title, subtitl
         Seamlessly Organized. Deliciously Simple.
       </motion.p>
       <motion.h2 
-        className="text-2xl font-semibold text-gray-700"
+        className="text-2xl font-semibold text-gray-700 dark:text-gray-200"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.6 }}
@@ -50,7 +50,7 @@ export const AuthBrandHeader: React.FC<AuthBrandHeaderProps> = ({ title, subtitl
         {title}
       </motion.h2>
       <motion.p 
-        className="mt-2 text-sm text-gray-600"
+        className="mt-2 text-sm text-gray-600 dark:text-gray-300"
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, delay: 0.7 }}

--- a/src/features/auth/components/AuthDivider.tsx
+++ b/src/features/auth/components/AuthDivider.tsx
@@ -8,10 +8,10 @@ export const AuthDivider: React.FC<AuthDividerProps> = ({ text }) => {
   return (
     <div className="relative">
       <div className="absolute inset-0 flex items-center">
-        <div className="w-full border-t border-gray-200"></div>
+        <div className="w-full border-t border-gray-200 dark:border-slate-700"></div>
       </div>
       <div className="relative flex justify-center text-sm">
-        <span className="px-2 bg-white text-gray-500">{text}</span>
+        <span className="px-2 bg-white dark:bg-slate-800 text-gray-500 dark:text-gray-400">{text}</span>
       </div>
     </div>
   )

--- a/src/features/auth/components/AuthFormInput.tsx
+++ b/src/features/auth/components/AuthFormInput.tsx
@@ -30,7 +30,7 @@ export const AuthFormInput: React.FC<AuthFormInputProps> = ({
 }) => {
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-semibold text-gray-700 mb-2">
+      <label htmlFor={id} className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
         {label}
       </label>
       <motion.div 
@@ -49,12 +49,12 @@ export const AuthFormInput: React.FC<AuthFormInputProps> = ({
           required={required}
           value={value}
           onChange={onChange}
-          className="block w-full pl-10 pr-3 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition duration-150"
+          className="block w-full pl-10 pr-3 py-3 border border-gray-300 dark:border-slate-600 rounded-lg shadow-sm bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition duration-150"
           placeholder={placeholder}
         />
       </motion.div>
       {error && (
-        <p className="mt-2 text-sm text-red-600 flex items-center">
+        <p className="mt-2 text-sm text-red-600 dark:text-red-300 flex items-center">
           <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
           </svg>

--- a/src/features/auth/components/AuthFormInput.tsx
+++ b/src/features/auth/components/AuthFormInput.tsx
@@ -49,7 +49,7 @@ export const AuthFormInput: React.FC<AuthFormInputProps> = ({
           required={required}
           value={value}
           onChange={onChange}
-          className="block w-full pl-10 pr-3 py-3 border border-gray-300 dark:border-slate-600 rounded-lg shadow-sm bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition duration-150"
+          className="block w-full pl-10 pr-3 py-3 border border-gray-300 dark:border-slate-600 rounded-lg shadow-sm bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition duration-150"
           placeholder={placeholder}
         />
       </motion.div>

--- a/src/features/auth/components/AuthFormLayout.tsx
+++ b/src/features/auth/components/AuthFormLayout.tsx
@@ -4,6 +4,7 @@ import { AuthBrandHeader } from './AuthBrandHeader'
 import { ErrorAlert } from './ErrorAlert'
 import { GoogleSignInButton } from './GoogleSignInButton'
 import { AuthDivider } from './AuthDivider'
+import { UI_STYLES } from '../../../utils/uiStyles'
 
 interface AuthFormLayoutProps {
   // Header
@@ -48,7 +49,7 @@ export const AuthFormLayout: React.FC<AuthFormLayoutProps> = ({
   bottomButtonAction,
 }) => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-teal-50 px-4 py-12">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-emerald-50 via-white to-teal-50 dark:from-slate-950 dark:via-slate-900 dark:to-emerald-950/40 px-4 py-12 transition-colors">
       <motion.div 
         className="max-w-md w-full"
         initial={{ opacity: 0, y: 20 }}
@@ -58,7 +59,7 @@ export const AuthFormLayout: React.FC<AuthFormLayoutProps> = ({
         <AuthBrandHeader title={title} subtitle={subtitle} />
         
         <motion.div 
-          className="bg-white rounded-2xl shadow-xl p-8 border border-gray-100"
+          className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 border border-gray-100 dark:border-slate-700"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.8 }}
@@ -109,11 +110,11 @@ export const AuthFormLayout: React.FC<AuthFormLayoutProps> = ({
           </div>
           
           <div className="mt-8 text-center text-sm font-medium">
-            <span className="text-gray-600">{bottomDividerText}</span>{' '}
+            <span className={UI_STYLES.mutedText}>{bottomDividerText}</span>{' '}
             <button
               type="button"
               onClick={bottomButtonAction}
-              className="text-emerald-600 hover:text-emerald-500 hover:underline transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 rounded px-1 -mx-1"
+              className="text-emerald-600 hover:text-emerald-500 hover:underline transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-slate-800 focus:ring-emerald-500 rounded px-1 -mx-1"
             >
               {bottomButtonText}
             </button>
@@ -121,7 +122,7 @@ export const AuthFormLayout: React.FC<AuthFormLayoutProps> = ({
         </motion.div>
         
         <motion.p 
-          className="mt-8 text-center text-xs text-gray-500"
+          className="mt-8 text-center text-xs text-gray-500 dark:text-gray-400"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 1 }}

--- a/src/features/auth/components/ErrorAlert.tsx
+++ b/src/features/auth/components/ErrorAlert.tsx
@@ -10,7 +10,7 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error }) => {
     <AnimatePresence>
       {error && (
         <motion.div 
-          className="rounded-lg bg-red-50 border border-red-200 p-4"
+          className="rounded-lg bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/60 p-4"
           initial={{ opacity: 0, height: 0, y: -10 }}
           animate={{ opacity: 1, height: "auto", y: 0 }}
           exit={{ opacity: 0, height: 0, y: -10 }}
@@ -20,7 +20,7 @@ export const ErrorAlert: React.FC<ErrorAlertProps> = ({ error }) => {
             <svg className="w-5 h-5 text-red-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
             </svg>
-            <p className="text-sm text-red-800">{error}</p>
+            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
           </div>
         </motion.div>
       )}

--- a/src/features/auth/components/GoogleSignInButton.tsx
+++ b/src/features/auth/components/GoogleSignInButton.tsx
@@ -16,7 +16,7 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="w-full flex justify-center items-center py-3 px-4 border-2 border-gray-300 rounded-lg shadow-sm text-sm font-semibold text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition duration-200"
+      className="w-full flex justify-center items-center py-3 px-4 border-2 border-gray-300 dark:border-slate-600 rounded-lg shadow-sm text-sm font-semibold text-gray-700 dark:text-gray-100 bg-white dark:bg-slate-900 hover:bg-gray-50 dark:hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-slate-800 focus:ring-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed transition duration-200"
     >
       <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
         <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>

--- a/src/features/community/CommunityPage.tsx
+++ b/src/features/community/CommunityPage.tsx
@@ -72,16 +72,16 @@ export const CommunityPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto">
       <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-4">Community Recipes</h1>
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">Community Recipes</h1>
 
         {user && (
-          <div className="flex border-b border-gray-200 mb-4">
+          <div className="flex border-b border-gray-200 dark:border-slate-700 mb-4">
             <button
               onClick={() => handleTabChange('community')}
               className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
                 activeTab === 'community'
                   ? 'border-emerald-500 text-emerald-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-slate-600'
               }`}
             >
               Community
@@ -91,7 +91,7 @@ export const CommunityPage: React.FC = () => {
               className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
                 activeTab === 'following'
                   ? 'border-emerald-500 text-emerald-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-slate-600'
               }`}
             >
               Following
@@ -99,7 +99,7 @@ export const CommunityPage: React.FC = () => {
           </div>
         )}
 
-        <p className="text-sm md:text-base text-gray-600">
+        <p className="text-sm md:text-base text-gray-600 dark:text-gray-300">
           {hasRecipes
             ? `Showing ${filtered.length} of ${recipes.length} ${recipes.length === 1 ? 'recipe' : 'recipes'} from the ${activeTab === 'following' ? 'cooks you follow' : 'community'}`
             : activeTab === 'following'
@@ -115,17 +115,17 @@ export const CommunityPage: React.FC = () => {
                 value={searchText}
                 onChange={(e) => setSearchText(e.target.value)}
                 placeholder="Search by recipe name..."
-                className="w-full sm:max-w-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
+                className="w-full sm:max-w-sm px-3 py-2 border border-gray-200 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-300"
               />
             </div>
             {activeTab === 'community' && (
               <div className="flex items-center gap-2">
-                <label htmlFor="community-sort" className="text-sm text-gray-600 whitespace-nowrap">Sort by:</label>
+                <label htmlFor="community-sort" className="text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">Sort by:</label>
                 <select
                   id="community-sort"
                   value={sortOption}
                   onChange={(e) => setSortOption(e.target.value as SortOption)}
-                  className="px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-300 bg-white"
+                  className="px-3 py-2 border border-gray-200 dark:border-slate-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-emerald-300 bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100"
                 >
                   <option value="recent">Most recent</option>
                   <option value="most-liked">Most liked</option>
@@ -177,7 +177,7 @@ export const CommunityPage: React.FC = () => {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
           </motion.svg>
           <motion.h3
-            className="mt-4 text-base sm:text-lg font-medium text-gray-900"
+            className="mt-4 text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 0.4 }}
@@ -185,7 +185,7 @@ export const CommunityPage: React.FC = () => {
             No community recipes yet
           </motion.h3>
           <motion.p
-            className="mt-2 text-sm sm:text-base text-gray-600"
+            className="mt-2 text-sm sm:text-base text-gray-600 dark:text-gray-300"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 0.5 }}
@@ -214,7 +214,7 @@ export const CommunityPage: React.FC = () => {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
           </motion.svg>
           <motion.h3
-            className="mt-4 text-base sm:text-lg font-medium text-gray-900"
+            className="mt-4 text-base sm:text-lg font-medium text-gray-900 dark:text-gray-100"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 0.4 }}
@@ -222,7 +222,7 @@ export const CommunityPage: React.FC = () => {
             No recipes from followed cooks yet
           </motion.h3>
           <motion.p
-            className="mt-2 text-sm sm:text-base text-gray-600"
+            className="mt-2 text-sm sm:text-base text-gray-600 dark:text-gray-300"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.4, delay: 0.5 }}
@@ -262,7 +262,7 @@ export const CommunityPage: React.FC = () => {
       )}
 
       {hasRecipes && filtered.length === 0 && (
-        <div className="mt-6 text-center text-gray-600">No recipes match your search.</div>
+        <div className="mt-6 text-center text-gray-600 dark:text-gray-300">No recipes match your search.</div>
       )}
     </div>
   )

--- a/src/features/help/HelpPage.tsx
+++ b/src/features/help/HelpPage.tsx
@@ -32,7 +32,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           Welcome to <strong>CookFlow</strong> — your personal recipe management app. Here's a quick overview of
           what you can do:
@@ -67,7 +67,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           The <strong>Browse Recipes</strong> page shows all the recipes you've saved. You can:
         </p>
@@ -102,7 +102,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           Click <strong>Create Recipe</strong> in the sidebar to open the step-by-step recipe builder. The form
           is split into four steps:
@@ -139,7 +139,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>To edit an existing recipe:</p>
         <ol className="list-decimal list-inside space-y-2 ml-2">
           <li>Open the recipe from <strong>Browse Recipes</strong> or the Dashboard.</li>
@@ -154,7 +154,7 @@ const helpSections: HelpSection[] = [
           <li>A confirmation dialog will appear — click <strong>Delete</strong> to confirm, or{' '}
             <strong>Cancel</strong> to go back.</li>
         </ul>
-        <p className="text-amber-600 text-sm">⚠ Deletion is permanent and cannot be undone.</p>
+        <p className="text-amber-600 dark:text-amber-400 text-sm">⚠ Deletion is permanent and cannot be undone.</p>
       </div>
     ),
   },
@@ -167,7 +167,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           The <strong>AI Generator</strong> creates recipe ideas for you automatically. To use it:
         </p>
@@ -198,7 +198,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           <strong>Cooking Mode</strong> presents a distraction-free, step-by-step view of a recipe while you
           cook.
@@ -223,7 +223,7 @@ const helpSections: HelpSection[] = [
       </svg>
     ),
     content: (
-      <div className="space-y-3 text-gray-600">
+      <div className="space-y-3 text-gray-600 dark:text-gray-300">
         <p>
           Your account email is shown at the bottom of the sidebar. All recipes are stored privately and linked
           to your account.
@@ -260,16 +260,16 @@ const AccordionItem: React.FC<{
     initial={{ opacity: 0, y: 10 }}
     animate={{ opacity: 1, y: 0 }}
     transition={{ delay: index * 0.05, duration: 0.3 }}
-    className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden"
+    className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 overflow-hidden"
   >
     <button
       onClick={onToggle}
-      className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-gray-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+      className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-gray-50 dark:hover:bg-slate-700/70 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
       aria-expanded={isOpen}
     >
       <div className="flex items-center space-x-3">
         <div className="text-emerald-600">{section.icon}</div>
-        <span className="font-medium text-gray-900">{section.title}</span>
+        <span className="font-medium text-gray-900 dark:text-gray-100">{section.title}</span>
       </div>
       <ChevronIcon isOpen={isOpen} />
     </button>
@@ -284,7 +284,7 @@ const AccordionItem: React.FC<{
           transition={{ duration: 0.25, ease: 'easeInOut' }}
           className="overflow-hidden"
         >
-          <div className="px-5 pb-5 pt-1 border-t border-gray-100">{section.content}</div>
+          <div className="px-5 pb-5 pt-1 border-t border-gray-100 dark:border-slate-700">{section.content}</div>
         </motion.div>
       )}
     </AnimatePresence>
@@ -346,9 +346,9 @@ export const HelpPage: React.FC = () => {
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.4, duration: 0.3 }}
-        className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 text-center"
+        className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 text-center"
       >
-        <p className="text-gray-600 mb-4">Ready to get cooking?</p>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">Ready to get cooking?</p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <motion.button
             whileHover={{ scale: 1.05 }}
@@ -362,7 +362,7 @@ export const HelpPage: React.FC = () => {
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={() => navigate('/dashboard/recipes')}
-            className="px-6 py-2.5 bg-white text-emerald-700 border border-emerald-300 rounded-lg font-medium hover:bg-emerald-50 transition-colors"
+            className="px-6 py-2.5 bg-white dark:bg-slate-900 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700/60 rounded-lg font-medium hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
           >
             Browse Recipes
           </motion.button>

--- a/src/features/recipes/AIGenerator.tsx
+++ b/src/features/recipes/AIGenerator.tsx
@@ -149,20 +149,20 @@ export const AIGenerator: React.FC = () => {
     <div className="max-w-6xl mx-auto">
       <div className="mb-8">
         <div className="flex items-center space-x-3 mb-2">
-          <h1 className="text-3xl font-bold text-gray-900">AI Recipe Generator</h1>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">AI Recipe Generator</h1>
           <span className="px-3 py-1 text-xs font-semibold text-emerald-700 bg-emerald-100 rounded-full">
             POWERED BY AI
           </span>
         </div>
-        <p className="text-gray-600">Generate custom recipes based on your preferences and ingredients</p>
+        <p className="text-gray-600 dark:text-gray-300">Generate custom recipes based on your preferences and ingredients</p>
       </div>
 
       {!result && (
-        <form onSubmit={handleGenerate} className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8">
+        <form onSubmit={handleGenerate} className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6 sm:p-8">
           <div className="space-y-6">
             {/* Description/Prompt */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-2">
+              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                 What would you like to make? (Optional)
               </label>
               <textarea
@@ -170,13 +170,13 @@ export const AIGenerator: React.FC = () => {
                 onChange={(e) => setPrompt(e.target.value)}
                 rows={2}
                 placeholder="e.g., 'a quick weeknight dinner', 'something spicy', 'healthy lunch'"
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                className="w-full px-4 py-3 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
               />
             </div>
 
             {/* Pantry Items */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-2">
+              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
                 Available Ingredients ({pantryItems.length})
               </label>
               <div className="relative">
@@ -191,7 +191,7 @@ export const AIGenerator: React.FC = () => {
                     }
                   }}
                   placeholder="Add ingredients..."
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+                  className="w-full px-4 py-3 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
               </div>
               {pantryItems.length > 0 && (
@@ -199,13 +199,13 @@ export const AIGenerator: React.FC = () => {
                   {pantryItems.map((item, idx) => (
                     <span
                       key={idx}
-                      className="inline-flex items-center px-3 py-1 bg-amber-100 text-amber-800 text-sm rounded-full"
+                      className="inline-flex items-center px-3 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300 text-sm rounded-full"
                     >
                       {item}
                       <button
                         type="button"
                         onClick={() => handleRemoveIngredient(idx)}
-                        className="ml-2 text-amber-600 hover:text-amber-800"
+                        className="ml-2 text-amber-600 dark:text-amber-300 hover:text-amber-800 dark:hover:text-amber-200"
                       >
                         ×
                       </button>
@@ -217,7 +217,7 @@ export const AIGenerator: React.FC = () => {
 
             {/* Dietary Preferences */}
             <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-3">
+              <label className="block text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">
                 Dietary Preferences (Optional)
               </label>
               <div className="flex flex-wrap gap-2">
@@ -229,7 +229,7 @@ export const AIGenerator: React.FC = () => {
                     className={`px-4 py-2 border rounded-full text-sm font-medium transition-colors ${
                       selectedDiets.includes(diet)
                         ? 'border-emerald-500 bg-emerald-50 text-emerald-700'
-                        : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                        : 'border-gray-300 dark:border-slate-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-700'
                     }`}
                   >
                     {diet}
@@ -240,13 +240,13 @@ export const AIGenerator: React.FC = () => {
 
             {/* Error Message */}
             {error && (
-              <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+              <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-500/40 rounded-lg text-red-700 dark:text-red-300">
                 {error}
               </div>
             )}
 
             {/* Generate Button */}
-            <div className="pt-6 border-t border-gray-200">
+            <div className="pt-6 border-t border-gray-200 dark:border-slate-700">
               <motion.button
                 type="submit"
                 disabled={loading}
@@ -276,12 +276,12 @@ export const AIGenerator: React.FC = () => {
       {/* Recipe Result */}
       {result && parsedRecipe && (
         <div className="space-y-6">
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8">
+          <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6 sm:p-8">
             <div className="flex flex-col sm:flex-row items-start justify-between gap-4 mb-6">
               <div className="flex-1">
-                <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">{parsedRecipe.recipeName}</h2>
+                <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">{parsedRecipe.recipeName}</h2>
                 {parsedRecipe.description && (
-                  <p className="mt-2 text-gray-600">{parsedRecipe.description}</p>
+                  <p className="mt-2 text-gray-600 dark:text-gray-300">{parsedRecipe.description}</p>
                 )}
                 {saveSuccess && (
                   <span className="inline-block mt-2 text-sm text-emerald-700 font-medium">✓ Saved to library</span>
@@ -327,11 +327,11 @@ export const AIGenerator: React.FC = () => {
                   disabled={loading}
                   aria-label="Regenerate recipe"
                   title="Regenerate recipe"
-                  className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
+                  className="flex-1 sm:flex-none inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-slate-900 border border-gray-300 dark:border-slate-600 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm"
                 >
                   {loading ? (
                     <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-700" />
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-gray-700 dark:border-gray-200" />
                       <span>Generating...</span>
                     </>
                   ) : (
@@ -378,15 +378,15 @@ export const AIGenerator: React.FC = () => {
                   </button>
                 </figure>
               ) : (
-                <div className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center bg-gray-50">
+                <div className="border-2 border-dashed border-gray-300 dark:border-slate-600 rounded-lg p-8 text-center bg-gray-50 dark:bg-slate-900">
                   {imageLoading ? (
                     <div className="flex flex-col items-center">
                       <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600 mb-4" />
-                      <p className="text-gray-600 font-medium">Generating recipe image...</p>
+                      <p className="text-gray-600 dark:text-gray-300 font-medium">Generating recipe image...</p>
                     </div>
                   ) : (
                     <>
-                      <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="w-16 h-16 text-gray-400 dark:text-gray-500 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
                       <button
@@ -399,7 +399,7 @@ export const AIGenerator: React.FC = () => {
                         <span>Generate Recipe Image</span>
                       </button>
                       {imageError && (
-                        <p className="mt-4 text-sm text-red-600 bg-red-50 px-4 py-2 rounded-lg inline-block">{imageError}</p>
+                        <p className="mt-4 text-sm text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-950/20 px-4 py-2 rounded-lg inline-block">{imageError}</p>
                       )}
                     </>
                   )}

--- a/src/features/recipes/CreateRecipe.tsx
+++ b/src/features/recipes/CreateRecipe.tsx
@@ -8,6 +8,7 @@ import { useRecipeSave } from './hooks/useRecipeSave'
 import { useAISuggestions } from './hooks/useAISuggestions'
 import { useIngredientNormalization } from './hooks/useIngredientNormalization'
 import type { Recipe } from '../../types/nutrition'
+import { UI_STYLES } from '../../utils/uiStyles'
 
 const FIELD_LABELS: Record<string, string> = {
   recipeName: 'Recipe Name',
@@ -95,18 +96,18 @@ export const CreateRecipe: React.FC = () => {
 
   const modeToggle = (
     <nav
-      className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 mb-6"
+      className="inline-flex rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 p-1 mb-6"
       aria-label="Recipe creation mode"
     >
       <span
         aria-current="page"
-        className="px-4 py-2 rounded-md text-sm font-medium bg-white text-emerald-700 shadow-sm border border-gray-200"
+        className="px-4 py-2 rounded-md text-sm font-medium bg-white dark:bg-slate-900 text-emerald-700 dark:text-emerald-300 shadow-sm border border-gray-200 dark:border-slate-600"
       >
         🧭 Guided (step-by-step)
       </span>
       <Link
         to="/dashboard/create/simple"
-        className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-white transition-colors"
+        className={`px-4 py-2 rounded-md text-sm font-medium transition-colors hover:bg-white dark:hover:bg-slate-900 ${UI_STYLES.mutedText} hover:text-gray-900 dark:hover:text-gray-100`}
       >
         ⚡ Quick entry
       </Link>

--- a/src/features/recipes/RecipeDetail.tsx
+++ b/src/features/recipes/RecipeDetail.tsx
@@ -170,7 +170,7 @@ export const RecipeDetail: React.FC = () => {
           </svg>
           Back
         </button>
-        <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg p-4">
+        <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/60 text-red-800 dark:text-red-200 rounded-lg p-4">
           <p className="font-medium">Error loading recipe</p>
           <p className="text-sm mt-1">{error || 'Recipe not found'}</p>
         </div>
@@ -215,7 +215,7 @@ export const RecipeDetail: React.FC = () => {
                 aria-label={isTogglingShare ? 'Updating…' : 'More options'}
                 title="More options"
                 disabled={isTogglingShare}
-                className="flex items-center justify-center w-9 h-9 rounded-full text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-60 disabled:cursor-not-allowed"
+                className="flex items-center justify-center w-9 h-9 rounded-full text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-400 disabled:opacity-60 disabled:cursor-not-allowed"
               >
                 {isTogglingShare ? (
                   <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
@@ -231,7 +231,7 @@ export const RecipeDetail: React.FC = () => {
                   id="recipe-options-menu"
                   role="menu"
                   aria-labelledby="recipe-options-button"
-                  className="absolute right-0 mt-1.5 w-48 rounded-xl bg-white dark:bg-gray-900 shadow-lg ring-1 ring-black/5 dark:ring-white/10 py-1 z-20 animate-[fadeIn_0.1s_ease]"
+                  className="absolute right-0 mt-1.5 w-48 rounded-xl bg-white dark:bg-slate-800 shadow-lg ring-1 ring-black/5 dark:ring-white/10 border border-gray-200 dark:border-slate-700 py-1 z-20 animate-[fadeIn_0.1s_ease]"
                 >
                   {isOwner && (
                     <button
@@ -280,7 +280,7 @@ export const RecipeDetail: React.FC = () => {
           {/* Primary CTA */}
           <button
             onClick={() => setIsCookingMode(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-full hover:bg-emerald-700 font-medium text-sm transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2"
+            className="flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-full hover:bg-emerald-700 font-medium text-sm transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -315,13 +315,13 @@ export const RecipeDetail: React.FC = () => {
       )}
 
       {/* Recipe title */}
-      <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-2">{recipe.recipeName}</h1>
+      <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">{recipe.recipeName}</h1>
 
       {/* Author link */}
       {recipe.userId ? (
         <Link
           to={`/user/${recipe.userId}`}
-          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-emerald-600 transition-colors mb-6"
+          className="inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors mb-6"
         >
           <div className="w-6 h-6 rounded-full bg-gradient-to-br from-emerald-600 to-teal-500 flex items-center justify-center text-white text-xs font-semibold">
             {(recipe.userId[0] || '?').toUpperCase()}
@@ -345,7 +345,7 @@ export const RecipeDetail: React.FC = () => {
       )}
 
       {/* Recipe details */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8">
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6 sm:p-8 transition-colors duration-300">
         <RecipeBody recipe={recipe} />
       </div>
 
@@ -358,15 +358,15 @@ export const RecipeDetail: React.FC = () => {
       {fallbackUrl && (
         <div
           role="alert"
-          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-white border border-emerald-600 rounded-lg shadow-lg px-6 py-4 flex items-start gap-4 max-w-sm w-full"
+          className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-white dark:bg-slate-800 border border-emerald-600 dark:border-emerald-500/70 rounded-lg shadow-lg px-6 py-4 flex items-start gap-4 max-w-sm w-full transition-colors duration-300"
         >
           <div className="flex-1">
-            <p className="text-sm font-medium text-gray-900 mb-1">Copy this link manually:</p>
-            <p className="text-sm text-gray-600 break-all">{fallbackUrl}</p>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">Copy this link manually:</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 break-all">{fallbackUrl}</p>
           </div>
           <button
             onClick={() => setFallbackUrl(null)}
-            className="text-gray-400 hover:text-gray-600 flex-shrink-0"
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 flex-shrink-0"
             aria-label="Dismiss"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/src/features/recipes/RecipeLibrary.tsx
+++ b/src/features/recipes/RecipeLibrary.tsx
@@ -193,8 +193,8 @@ export const RecipeLibrary: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto">
       <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">Recipe Library</h1>
-        <p className="text-sm md:text-base text-gray-600">Showing {filtered.length} of {recipes.length} {recipes.length === 1 ? 'recipe' : 'recipes'} in your collection</p>
+        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Recipe Library</h1>
+        <p className="text-sm md:text-base text-gray-600 dark:text-gray-300">Showing {filtered.length} of {recipes.length} {recipes.length === 1 ? 'recipe' : 'recipes'} in your collection</p>
         <div className="mt-4 flex flex-col sm:flex-row gap-3 sm:gap-4 sm:items-center">
           <label htmlFor="search" className="sr-only">Search recipes</label>
           <input
@@ -202,7 +202,7 @@ export const RecipeLibrary: React.FC = () => {
             value={searchText}
             onChange={(e) => setSearchText(e.target.value)}
             placeholder="Search by title, description or tag..."
-            className="flex-1 px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
+            className="flex-1 px-3 py-2 border border-gray-200 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-300"
           />
 
           <label htmlFor="tag-filter" className="sr-only">Filter by tag</label>
@@ -210,7 +210,7 @@ export const RecipeLibrary: React.FC = () => {
             id="tag-filter"
             value={selectedTag || ''}
             onChange={(e) => setSelectedTag(e.target.value || null)}
-            className="px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
+            className="px-3 py-2 border border-gray-200 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-300"
           >
             <option value="">All tags</option>
             {tags.map(tag => (
@@ -254,13 +254,13 @@ export const RecipeLibrary: React.FC = () => {
 
               {/* Empty filtered state */}
               {filtered.length === 0 && (
-                <div className="mt-6 text-center text-gray-600">No recipes match your search or selected tag.</div>
+                <div className="mt-6 text-center text-gray-600 dark:text-gray-300">No recipes match your search or selected tag.</div>
               )}
 
             {/* Pagination controls */}
             {filtered.length > pageSize && (
               <div className="mt-6 flex items-center justify-between">
-                <div className="text-sm text-gray-600">
+                <div className="text-sm text-gray-600 dark:text-gray-300">
                   Showing {Math.min(start + 1, total)} - {Math.min(end, total)} of {total}
                 </div>
 
@@ -268,7 +268,7 @@ export const RecipeLibrary: React.FC = () => {
                   <button
                     onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
                     disabled={currentPage === 1}
-                    className="px-3 py-1 bg-gray-100 rounded disabled:opacity-50"
+                    className="px-3 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-gray-200 rounded disabled:opacity-50"
                     aria-label="Previous page"
                   >
                     Previous
@@ -280,7 +280,7 @@ export const RecipeLibrary: React.FC = () => {
                       key={p}
                       onClick={() => setCurrentPage(p)}
                       aria-current={p === currentPage}
-                      className={`px-3 py-1 rounded ${p === currentPage ? 'bg-emerald-600 text-white' : 'bg-gray-100'}`}
+                      className={`px-3 py-1 rounded ${p === currentPage ? 'bg-emerald-600 text-white' : 'bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-gray-200'}`}
                       aria-label={`Go to page ${p}`}
                     >
                       {p}
@@ -290,7 +290,7 @@ export const RecipeLibrary: React.FC = () => {
                   <button
                     onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
                     disabled={currentPage === totalPages}
-                    className="px-3 py-1 bg-gray-100 rounded disabled:opacity-50"
+                    className="px-3 py-1 bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-gray-200 rounded disabled:opacity-50"
                     aria-label="Next page"
                   >
                     Next
@@ -313,7 +313,7 @@ export const RecipeLibrary: React.FC = () => {
             transition={{ duration: 0.2 }}
           >
             <motion.div 
-              className="bg-white rounded-lg max-w-md w-full p-4 sm:p-6"
+              className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg max-w-md w-full p-4 sm:p-6"
               initial={{ scale: 0.9, opacity: 0, y: 20 }}
               animate={{ scale: 1, opacity: 1, y: 0 }}
               exit={{ scale: 0.9, opacity: 0, y: 20 }}
@@ -326,12 +326,12 @@ export const RecipeLibrary: React.FC = () => {
                 </svg>
               </div>
               <div>
-                <h3 className="text-base sm:text-lg font-semibold text-gray-900">Delete Recipe</h3>
-                <p className="text-xs sm:text-sm text-gray-600 mt-1">This action cannot be undone</p>
+                <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100">Delete Recipe</h3>
+                <p className="text-xs sm:text-sm text-gray-600 dark:text-gray-300 mt-1">This action cannot be undone</p>
               </div>
             </div>
 
-            <p className="text-sm sm:text-base text-gray-700 mb-6">
+            <p className="text-sm sm:text-base text-gray-700 dark:text-gray-200 mb-6">
               Are you sure you want to delete <strong>"{deleteConfirm.title}"</strong>?
             </p>
 
@@ -339,7 +339,7 @@ export const RecipeLibrary: React.FC = () => {
               <button
                 onClick={handleDeleteCancel}
                 disabled={deleting}
-                className="px-4 py-2.5 sm:py-2 text-sm sm:text-base text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 active:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed min-w-[80px]"
+                className="px-4 py-2.5 sm:py-2 text-sm sm:text-base text-gray-700 dark:text-gray-200 bg-gray-100 dark:bg-slate-700 rounded-lg hover:bg-gray-200 dark:hover:bg-slate-600 active:bg-gray-300 dark:active:bg-slate-500 disabled:opacity-50 disabled:cursor-not-allowed min-w-[80px]"
               >
                 Cancel
               </button>

--- a/src/features/recipes/SavedRecipesPage.tsx
+++ b/src/features/recipes/SavedRecipesPage.tsx
@@ -17,8 +17,8 @@ export const SavedRecipesPage: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Saved Recipes</h1>
-          <p className="text-gray-600">Your bookmarked recipe collection</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Saved Recipes</h1>
+          <p className="text-gray-600 dark:text-gray-300">Your bookmarked recipe collection</p>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
           {Array.from({ length: 6 }).map((_, index) => (
@@ -40,14 +40,14 @@ export const SavedRecipesPage: React.FC = () => {
     return (
       <div className="max-w-7xl mx-auto">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Saved Recipes</h1>
-          <p className="text-gray-600">Your bookmarked recipe collection</p>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Saved Recipes</h1>
+          <p className="text-gray-600 dark:text-gray-300">Your bookmarked recipe collection</p>
         </div>
         <div
           data-testid="empty-state"
           className="flex flex-col items-center justify-center py-20 text-center"
         >
-          <div className="w-20 h-20 rounded-full bg-emerald-50 flex items-center justify-center mb-4">
+          <div className="w-20 h-20 rounded-full bg-emerald-50 dark:bg-emerald-900/30 flex items-center justify-center mb-4">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
@@ -64,8 +64,8 @@ export const SavedRecipesPage: React.FC = () => {
               />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">No saved recipes yet</h2>
-          <p className="text-gray-500 mb-6 max-w-sm">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">No saved recipes yet</h2>
+          <p className="text-gray-500 dark:text-gray-400 mb-6 max-w-sm">
             Save recipes you love by clicking the bookmark icon on any recipe card or detail page.
           </p>
           <button
@@ -82,8 +82,8 @@ export const SavedRecipesPage: React.FC = () => {
   return (
     <div className="max-w-7xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">Saved Recipes</h1>
-        <p className="text-gray-600">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Saved Recipes</h1>
+        <p className="text-gray-600 dark:text-gray-300">
           {savedRecipes.length} {savedRecipes.length === 1 ? 'recipe' : 'recipes'} saved
         </p>
       </div>

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -217,7 +217,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
         {/* Header */}
       <div className="mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100">
             {isEditMode ? 'Edit Recipe' : 'Create Recipe'}
           </h1>
           <div className="flex items-center gap-2">
@@ -251,19 +251,19 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
         {/* Entry-point mode toggle */}
         {!isEditMode && (
           <nav
-            className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 mb-6"
+            className="inline-flex rounded-lg border border-gray-200 dark:border-slate-700 bg-gray-50 dark:bg-slate-800 p-1 mb-6"
             aria-label="Recipe creation mode"
           >
             <Link
               to="/dashboard/create"
-              className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-white transition-colors"
+              className="px-4 py-2 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-white dark:hover:bg-slate-900 transition-colors"
             >
               🧭 Guided (step-by-step)
             </Link>
             <Link
               to="/dashboard/create/simple"
               aria-current="page"
-              className="px-4 py-2 rounded-md text-sm font-medium bg-white text-emerald-700 shadow-sm border border-gray-200"
+              className="px-4 py-2 rounded-md text-sm font-medium bg-white dark:bg-slate-900 text-emerald-700 dark:text-emerald-300 shadow-sm border border-gray-200 dark:border-slate-600"
             >
               ⚡ Quick entry
             </Link>
@@ -322,8 +322,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
 
       <form onSubmit={handleSubmit} noValidate className="space-y-6">
         {/* ─── Required: Title ─── */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4 pb-2 border-b border-gray-100">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 pb-2 border-b border-gray-100 dark:border-slate-700">
             Basic Info
           </h2>
 
@@ -430,8 +430,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
         </div>
 
         {/* ─── Required: Ingredients ─── */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4 pb-2 border-b border-gray-100">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4 pb-2 border-b border-gray-100 dark:border-slate-700">
             Ingredients <span className="text-red-500">*</span>
           </h2>
           <IngredientInput
@@ -463,9 +463,9 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
         </div>
 
         {/* ─── Required: Instructions ─── */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+        <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6">
           <div className="flex items-center justify-between mb-4 pb-2 border-b border-gray-100">
-            <h2 className="text-lg font-semibold text-gray-900">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
               Instructions <span className="text-red-500">*</span>
             </h2>
             <button type="button" onClick={form.addInstruction} className={UI_STYLES.addButton}>
@@ -707,7 +707,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
             data-testid="section-nutrition"
           >
             <div className="space-y-4">
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 Let AI calculate nutrition when your recipe does not already include it.
               </p>
               <button
@@ -733,7 +733,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               />
               {hasSavedNutrition && activeRecipeOverrides.nutritionalInfo && (
                 <div className="space-y-3">
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
                     AI nutrition values will be saved with this recipe unless you recalculate or dismiss them.
                   </p>
                   <NutritionFacts nutritionalInfo={activeRecipeOverrides.nutritionalInfo} />
@@ -863,7 +863,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
           >
             {!form.imagePreview ? (
               <div className="flex items-center justify-center w-full">
-                <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
+                <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-gray-300 dark:border-slate-600 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:bg-slate-900 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors">
                   <div className="flex flex-col items-center justify-center pt-5 pb-6">
                     <svg
                       className="w-10 h-10 mb-3 text-gray-400"
@@ -926,11 +926,11 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
         </div>
 
         {/* ─── Action bar ─── */}
-        <div className="sticky bottom-0 bg-white border-t border-gray-200 rounded-b-xl px-6 py-4 flex items-center justify-between gap-4 shadow-lg">
+        <div className="sticky bottom-0 bg-white dark:bg-slate-800 border-t border-gray-200 dark:border-slate-700 rounded-b-xl px-6 py-4 flex items-center justify-between gap-4 shadow-lg">
           <button
             type="button"
             onClick={handleCancel}
-            className="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition-colors"
+            className="px-6 py-3 border border-gray-300 dark:border-slate-600 rounded-lg text-gray-700 dark:text-gray-200 font-medium hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
           >
             Cancel
           </button>

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -568,11 +568,11 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               type="button"
               onClick={handlePreviousStepClick}
               disabled={!canGoPrevious}
-              className={`px-6 py-3 rounded-lg font-medium transition-colors ${
-                !canGoPrevious
-                  ? 'bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-gray-500 cursor-not-allowed'
-                  : UI_STYLES.backButton
-              }`}
+              className={
+                canGoPrevious
+                  ? UI_STYLES.backButton
+                  : 'px-6 py-3 rounded-lg font-medium transition-colors bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+              }
             >
               ← Back
             </button>

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -17,6 +17,7 @@ import { NutritionEstimatePanel } from './NutritionEstimatePanel'
 import { AI_BUTTON_CLASS } from './aiStyles'
 import type { Ingredient, Recipe } from '../../../types/nutrition'
 import NutritionFacts from '../../../components/NutritionFacts'
+import { UI_STYLES } from '../../../utils/uiStyles'
 
 interface RecipeFormLayoutProps {
   // Mode
@@ -380,10 +381,10 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
       <div className="mb-6 sm:mb-8">
         <div className="flex items-center justify-between mb-4 sm:mb-6">
           <div>
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-1 sm:mb-2">
+            <h1 className={`text-2xl sm:text-3xl font-bold mb-1 sm:mb-2 ${UI_STYLES.heading}`}>
               {mode === 'create' ? 'Create Recipe' : 'Edit Recipe'}
             </h1>
-            <p className="text-sm sm:text-base text-gray-600">
+            <p className={`text-sm sm:text-base ${UI_STYLES.mutedText}`}>
               Step {currentStep} of {totalSteps}: {steps[currentStep - 1].title}
             </p>
           </div>
@@ -468,7 +469,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
           saveLoading={saveLoading}
         />
       ) : (
-        <form className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8">
+        <form className={`${UI_STYLES.surfaceCard} p-6 sm:p-8`}>
           <div>
             <RecipeFormSteps
                 currentStep={currentStep}
@@ -552,7 +553,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               />
               {hasSavedNutrition && nutritionalInfo && (
                 <div className="mt-4 space-y-3">
-                  <p className="text-sm text-gray-600">
+                  <p className={`text-sm ${UI_STYLES.mutedText}`}>
                     AI nutrition values will be saved with this recipe unless you recalculate or dismiss them.
                   </p>
                   <NutritionFacts nutritionalInfo={nutritionalInfo} />
@@ -562,15 +563,15 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
           )}
 
           {/* Navigation Buttons */}
-          <div className="flex justify-between items-center gap-4 pt-6 border-t border-gray-200">
+          <div className="flex justify-between items-center gap-4 pt-6 border-t border-gray-200 dark:border-slate-700">
             <button
               type="button"
               onClick={handlePreviousStepClick}
               disabled={!canGoPrevious}
               className={`px-6 py-3 rounded-lg font-medium transition-colors ${
                 !canGoPrevious
-                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                  ? 'bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+                  : UI_STYLES.backButton
               }`}
             >
               ← Back
@@ -580,7 +581,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
               <button
                 type="button"
                 onClick={handleCancel}
-                className="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition-colors"
+                className={UI_STYLES.secondaryButtonNeutral}
               >
                 Cancel
               </button>

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -143,14 +143,14 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
       {/* Step 1: Basic Info */}
       {currentStep === 1 && (
         <div className="space-y-6">
-          <h2 className="text-xl font-semibold text-gray-900 pb-2 border-b border-gray-200">
+          <h2 className={`text-xl font-semibold pb-2 border-b border-gray-200 dark:border-slate-700 ${UI_STYLES.heading}`}>
             Basic Information
           </h2>
 
           {/* Recipe Name */}
           <div>
             <div className="flex items-center gap-1.5 mb-2">
-              <label className="text-sm font-semibold text-gray-700">
+              <label className={UI_STYLES.label}>
                 Recipe Name <span className="text-red-500">*</span>
               </label>
               {onEnhanceField && (
@@ -176,11 +176,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               placeholder="e.g., Grandma's Chocolate Chip Cookies"
               aria-invalid={!!fieldErrors.title}
               aria-describedby={fieldErrors.title ? 'title-error' : undefined}
-              className={`w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:border-transparent ${
-                fieldErrors.title
-                  ? 'border-red-500 focus:ring-red-500'
-                  : 'border-gray-300 focus:ring-emerald-500'
-              }`}
+              className={fieldErrors.title ? UI_STYLES.inputError : UI_STYLES.input}
             />
             {fieldErrors.title && (
               <p id="title-error" className="mt-1 text-sm text-red-600 flex items-center" role="alert">
@@ -207,7 +203,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
           {/* Description */}
           <div>
             <div className="flex items-center gap-1.5 mb-2">
-              <label className="text-sm font-semibold text-gray-700">
+              <label className={UI_STYLES.label}>
                 Description
               </label>
               {onEnhanceField && (
@@ -224,7 +220,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               onChange={(e) => setDescription(e.target.value)}
               rows={3}
               placeholder="Brief description of your recipe..."
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+              className={UI_STYLES.input}
             />
             {onEnhanceField && (() => {
               const s = getFieldSuggestion('description')
@@ -242,21 +238,21 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
 
           {/* Recipe Image Upload */}
           <div>
-            <label className="block text-sm font-semibold text-gray-700 mb-2">
+            <label className={`block mb-2 ${UI_STYLES.label}`}>
               Recipe Image
             </label>
 
             {!imagePreview ? (
               <div className="flex items-center justify-center w-full">
-                <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 transition-colors">
+                <label className="flex flex-col items-center justify-center w-full h-48 border-2 border-gray-300 dark:border-slate-600 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:bg-slate-900 hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors">
                   <div className="flex flex-col items-center justify-center pt-5 pb-6">
-                    <svg className="w-10 h-10 mb-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-10 h-10 mb-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                     </svg>
-                    <p className="mb-2 text-sm text-gray-500">
+                    <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
                       <span className="font-semibold">Click to upload</span> or drag and drop
                     </p>
-                    <p className="text-xs text-gray-500">PNG, JPG, or WEBP (recommended max size: 5MB)</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">PNG, JPG, or WEBP (recommended max size: 5MB)</p>
                   </div>
                   <input
                     type="file"
@@ -331,12 +327,12 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
             onDismissNormalization={onDismissNormalization}
           />
           {fieldErrors.ingredients && (
-            <div className="p-4 bg-red-50 border border-red-200 rounded-lg flex items-start">
+            <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-500/40 rounded-lg flex items-start">
               <svg className="w-5 h-5 text-red-600 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
               <div className="flex-1">
-                <p className="text-sm font-medium text-red-800">{fieldErrors.ingredients}</p>
+                <p className="text-sm font-medium text-red-800 dark:text-red-300">{fieldErrors.ingredients}</p>
               </div>
             </div>
           )}
@@ -348,8 +344,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
         <div className="space-y-8">
           {/* Instructions Section */}
           <div className="space-y-4">
-            <div className="flex items-center justify-between pb-2 border-b border-gray-200">
-              <h2 className="text-xl font-semibold text-gray-900">
+            <div className="flex items-center justify-between pb-2 border-b border-gray-200 dark:border-slate-700">
+              <h2 className={`text-xl font-semibold ${UI_STYLES.heading}`}>
                 Instructions <span className="text-red-500">*</span>
               </h2>
               <div className="flex gap-2">
@@ -401,7 +397,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
           placeholder="Describe this step in detail..."
           required={index === 0}
           rows={2}
-          className="w-full px-4 py-2.5 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent resize-none"
+          className={`${UI_STYLES.input} resize-none`}
         />
         {isPending && refinementState && onAcceptInstructionRefinement && onRejectInstructionRefinement && (
           <div className="mt-2">

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -327,7 +327,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
             onDismissNormalization={onDismissNormalization}
           />
           {fieldErrors.ingredients && (
-            <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-500/40 rounded-lg flex items-start">
+            <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-500/70 rounded-lg flex items-start">
               <svg className="w-5 h-5 text-red-600 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>

--- a/src/features/recipes/components/RecipePreview.tsx
+++ b/src/features/recipes/components/RecipePreview.tsx
@@ -41,21 +41,21 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
   saveLoading
 }) => {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+    <div className={`${UI_STYLES.surfaceCard} p-8`}>
       {/* Error message */}
       {saveError && (
-        <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-start" role="alert">
+        <div className="mb-6 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-500/40 rounded-lg flex items-start" role="alert">
           <svg className="w-5 h-5 text-red-600 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
           </svg>
           <div className="flex-1">
-            <h3 className="text-sm font-medium text-red-800">Error saving recipe</h3>
-            <p className="text-sm text-red-700 mt-1">{saveError}</p>
+            <h3 className="text-sm font-medium text-red-800 dark:text-red-300">Error saving recipe</h3>
+            <p className="text-sm text-red-700 dark:text-red-300/90 mt-1">{saveError}</p>
           </div>
           <button
             type="button"
             onClick={() => setSaveError(null)}
-            className="ml-3 text-red-600 hover:text-red-800 transition-colors"
+            className="ml-3 text-red-600 dark:text-red-300 hover:text-red-800 dark:hover:text-red-200 transition-colors"
             aria-label="Dismiss"
           >
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
@@ -67,12 +67,12 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
 
       {/* Recipe header */}
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">
+        <h1 className={`text-4xl font-bold mb-4 ${UI_STYLES.heading}`}>
           {title || 'Untitled Recipe'}
         </h1>
 
         {description && (
-          <p className="text-lg text-gray-600 mb-6">{description}</p>
+        <p className={`text-lg mb-6 ${UI_STYLES.mutedText}`}>{description}</p>
         )}
 
         {/* Recipe image */}
@@ -87,38 +87,38 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
         )}
 
         {/* Recipe meta */}
-        <div className="flex flex-wrap gap-6 pb-6 border-b border-gray-200">
+        <div className="flex flex-wrap gap-6 pb-6 border-b border-gray-200 dark:border-slate-700">
           {prepTime && (
-            <div className="flex items-center text-gray-700">
+            <div className="flex items-center text-gray-700 dark:text-gray-200">
               <svg className="w-5 h-5 mr-2 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div>
-                <div className="text-sm text-gray-500">Prep Time</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">Prep Time</div>
                 <div className="font-medium">{prepTime} min</div>
               </div>
             </div>
           )}
 
           {cookTime && (
-            <div className="flex items-center text-gray-700">
+            <div className="flex items-center text-gray-700 dark:text-gray-200">
               <svg className="w-5 h-5 mr-2 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z" />
               </svg>
               <div>
-                <div className="text-sm text-gray-500">Cook Time</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">Cook Time</div>
                 <div className="font-medium">{cookTime} min</div>
               </div>
             </div>
           )}
 
           {servings && (
-            <div className="flex items-center text-gray-700">
+            <div className="flex items-center text-gray-700 dark:text-gray-200">
               <svg className="w-5 h-5 mr-2 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
               </svg>
               <div>
-                <div className="text-sm text-gray-500">Servings</div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">Servings</div>
                 <div className="font-medium">{servings}</div>
               </div>
             </div>
@@ -129,14 +129,14 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
       {/* Ingredients */}
       {ingredients.filter(i => i.item.trim()).length > 0 && (
         <div className="mt-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">Ingredients</h2>
+          <h2 className={`text-2xl font-bold mb-4 ${UI_STYLES.heading}`}>Ingredients</h2>
           <ul className="space-y-2">
             {ingredients.filter(i => i.item.trim()).map((ingredient, index) => (
               <li key={index} className="flex items-start">
                 <svg className="w-5 h-5 mr-3 mt-0.5 text-emerald-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span className="text-gray-700">
+                <span className="text-gray-700 dark:text-gray-200">
                   {[ingredient.quantity, ingredient.unit, ingredient.item]
                     .filter(p => p.trim())
                     .join(' ')}
@@ -150,14 +150,14 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
       {/* Instructions */}
       {instructions.filter(i => i.trim()).length > 0 && (
         <div className="mt-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">Instructions</h2>
+          <h2 className={`text-2xl font-bold mb-4 ${UI_STYLES.heading}`}>Instructions</h2>
           <ol className="space-y-4">
             {instructions.filter(i => i.trim()).map((instruction, index) => (
               <li key={index} className="flex items-start">
                 <span className="flex items-center justify-center w-8 h-8 rounded-full bg-emerald-600 text-white font-bold text-sm mr-4 flex-shrink-0 mt-0.5">
                   {index + 1}
                 </span>
-                <p className="text-gray-700 pt-1">{instruction}</p>
+                <p className="text-gray-700 dark:text-gray-200 pt-1">{instruction}</p>
               </li>
             ))}
           </ol>
@@ -166,13 +166,13 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
 
       {/* Tags */}
       {tags.length > 0 && (
-        <div className="mt-8 pt-6 border-t border-gray-200">
-          <h3 className="text-sm font-medium text-gray-500 mb-3">Tags</h3>
+        <div className="mt-8 pt-6 border-t border-gray-200 dark:border-slate-700">
+        <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">Tags</h3>
           <div className="flex flex-wrap gap-2">
             {tags.map((tag, index) => (
               <span
                 key={index}
-                className="px-3 py-1 bg-emerald-50 text-emerald-700 rounded-full text-sm font-medium"
+                className="px-3 py-1 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm font-medium"
               >
                 {tag}
               </span>
@@ -182,11 +182,11 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
       )}
 
       {/* Action buttons in preview mode */}
-      <div className="flex items-center justify-between pt-8 mt-8 border-t border-gray-200">
+      <div className="flex items-center justify-between pt-8 mt-8 border-t border-gray-200 dark:border-slate-700">
         <button
           type="button"
           onClick={prevStep}
-          className="px-6 py-3 rounded-lg font-medium transition-colors bg-gray-200 text-gray-700 hover:bg-gray-300"
+          className={UI_STYLES.backButton}
         >
           ← Back
         </button>
@@ -195,7 +195,7 @@ export const RecipePreview = React.memo<RecipePreviewProps>(({
             type="button"
             onClick={handleCancel}
             disabled={saveLoading}
-            className="px-6 py-3 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className={`${UI_STYLES.secondaryButtonNeutral} disabled:opacity-50 disabled:cursor-not-allowed`}
           >
             Cancel
           </button>

--- a/src/features/recipes/components/StepIndicator.tsx
+++ b/src/features/recipes/components/StepIndicator.tsx
@@ -39,7 +39,7 @@ export const StepIndicator = React.memo<StepIndicatorProps>(({
                     ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
                     : 'bg-gray-200 dark:bg-slate-800 text-gray-500 dark:text-gray-400'
               } ${
-                stepsWithErrors.has(step.number) ? 'ring-2 ring-red-500 ring-offset-2' : ''
+                stepsWithErrors.has(step.number) ? 'ring-2 ring-red-500 ring-offset-2 dark:ring-offset-slate-900' : ''
               }`}
             >
               {step.number < currentStep ? '✓' : step.icon}

--- a/src/features/recipes/components/StepIndicator.tsx
+++ b/src/features/recipes/components/StepIndicator.tsx
@@ -36,8 +36,8 @@ export const StepIndicator = React.memo<StepIndicatorProps>(({
                 step.number === currentStep
                   ? 'bg-emerald-600 text-white shadow-lg'
                   : step.number < currentStep
-                  ? 'bg-emerald-100 text-emerald-700'
-                  : 'bg-gray-200 text-gray-500'
+                    ? 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300'
+                    : 'bg-gray-200 dark:bg-slate-800 text-gray-500 dark:text-gray-400'
               } ${
                 stepsWithErrors.has(step.number) ? 'ring-2 ring-red-500 ring-offset-2' : ''
               }`}
@@ -50,14 +50,14 @@ export const StepIndicator = React.memo<StepIndicatorProps>(({
               )}
             </div>
             <span className={`text-xs sm:text-sm font-medium whitespace-nowrap ${
-              step.number === currentStep ? 'text-gray-900' : stepsWithErrors.has(step.number) ? 'text-red-600' : 'text-gray-500'
+              step.number === currentStep ? 'text-gray-900 dark:text-gray-100' : stepsWithErrors.has(step.number) ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'
             }`}>
               {step.title}
             </span>
           </button>
           {index < steps.length - 1 && (
             <div className={`flex-1 h-1 mx-2 rounded ${
-              step.number < currentStep ? 'bg-emerald-600' : 'bg-gray-200'
+              step.number < currentStep ? 'bg-emerald-600' : 'bg-gray-200 dark:bg-slate-800'
             }`} />
           )}
         </React.Fragment>

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -35,6 +35,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     } else {
       root.classList.remove('dark');
     }
+    root.dataset.theme = theme
+    root.style.colorScheme = theme
     
     try {
       window.localStorage.setItem('theme', theme);

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -35,8 +35,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     } else {
       root.classList.remove('dark');
     }
-    root.dataset.theme = theme
-    root.style.colorScheme = theme
+    root.dataset.theme = theme;
     
     try {
       window.localStorage.setItem('theme', theme);

--- a/src/features/users/FollowListModal.tsx
+++ b/src/features/users/FollowListModal.tsx
@@ -94,9 +94,9 @@ export const FollowListModal: React.FC<FollowListModalProps> = ({ uid, type, onC
                 />
               </div>
             ) : error ? (
-              <p className="text-center text-red-600 py-8 text-sm">{error}</p>
+              <p className="text-center text-red-600 dark:text-red-300 py-8 text-sm">{error}</p>
             ) : users.length === 0 ? (
-              <p className="text-center text-gray-500 py-8 text-sm">
+              <p className="text-center text-gray-500 dark:text-gray-400 py-8 text-sm">
                 {type === 'followers' ? 'No followers yet.' : 'Not following anyone yet.'}
               </p>
             ) : (

--- a/src/features/users/UserProfilePage.tsx
+++ b/src/features/users/UserProfilePage.tsx
@@ -73,9 +73,9 @@ export const UserProfilePage: React.FC = () => {
           Go Back
         </button>
         <div className="text-center py-16">
-          <div className="text-6xl font-bold text-gray-300 mb-4">404</div>
-          <h2 className="text-2xl font-semibold text-gray-700 mb-2">User not found</h2>
-          <p className="text-gray-500">The profile you're looking for doesn't exist or has been removed.</p>
+          <div className="text-6xl font-bold text-gray-300 dark:text-gray-600 mb-4">404</div>
+          <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-100 mb-2">User not found</h2>
+          <p className="text-gray-500 dark:text-gray-400">The profile you're looking for doesn't exist or has been removed.</p>
         </div>
       </div>
     )
@@ -118,7 +118,7 @@ export const UserProfilePage: React.FC = () => {
 
       {/* Profile header */}
       <motion.div
-        className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8 mb-8"
+        className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6 sm:p-8 mb-8"
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3 }}
@@ -139,7 +139,7 @@ export const UserProfilePage: React.FC = () => {
 
           {/* Info */}
           <div className="flex-1 text-center sm:text-left">
-            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-1">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-1">
               {profile.displayName}
             </h1>
 
@@ -154,9 +154,9 @@ export const UserProfilePage: React.FC = () => {
                     <button
                       type="button"
                       onClick={() => setFollowModal('followers')}
-                      className="text-sm text-gray-600 hover:text-emerald-600 transition-colors focus:outline-none"
+                      className="text-sm text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors focus:outline-none"
                     >
-                      <span className="font-semibold text-gray-900">{displayFollowerCount}</span>
+                      <span className="font-semibold text-gray-900 dark:text-gray-100">{displayFollowerCount}</span>
                       {' '}
                       {displayFollowerCount === 1 ? 'follower' : 'followers'}
                     </button>
@@ -165,9 +165,9 @@ export const UserProfilePage: React.FC = () => {
                     <button
                       type="button"
                       onClick={() => setFollowModal('following')}
-                      className="text-sm text-gray-600 hover:text-emerald-600 transition-colors focus:outline-none"
+                      className="text-sm text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors focus:outline-none"
                     >
-                      <span className="font-semibold text-gray-900">{profile.followingCount}</span>
+                      <span className="font-semibold text-gray-900 dark:text-gray-100">{profile.followingCount}</span>
                       {' '}
                       following
                     </button>
@@ -177,9 +177,9 @@ export const UserProfilePage: React.FC = () => {
             })()}
 
             {profile.bio && (
-              <p className="text-gray-600 mb-3">{profile.bio}</p>
+              <p className="text-gray-600 dark:text-gray-300 mb-3">{profile.bio}</p>
             )}
-            <p className="text-sm text-gray-500 mb-4">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
               {profile.publicRecipeCount}{' '}
               {profile.publicRecipeCount === 1 ? 'public recipe' : 'public recipes'}
             </p>
@@ -191,11 +191,11 @@ export const UserProfilePage: React.FC = () => {
       </motion.div>
 
       {/* Public recipes grid */}
-      <h2 className="text-xl font-bold text-gray-900 mb-4">Public Recipes</h2>
+      <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Public Recipes</h2>
 
       {profile.publicRecipes.length === 0 ? (
         <motion.div
-          className="text-center py-12 text-gray-500"
+          className="text-center py-12 text-gray-500 dark:text-gray-400"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3 }}
@@ -238,14 +238,14 @@ export const UserProfilePage: React.FC = () => {
 
 export const UserProfilePageSkeleton: React.FC = () => (
   <div className="max-w-4xl mx-auto px-4 py-8">
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 sm:p-8 mb-8 animate-pulse">
+    <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700 p-6 sm:p-8 mb-8 animate-pulse">
       <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6">
-        <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gray-200 flex-shrink-0" />
+        <div className="w-20 h-20 sm:w-24 sm:h-24 rounded-full bg-gray-200 dark:bg-slate-700 flex-shrink-0" />
         <div className="flex-1 space-y-3">
-          <div className="h-7 bg-gray-200 rounded w-48" />
-          <div className="h-4 bg-gray-200 rounded w-64" />
-          <div className="h-4 bg-gray-200 rounded w-24" />
-          <div className="h-9 bg-gray-200 rounded w-24" />
+          <div className="h-7 bg-gray-200 dark:bg-slate-700 rounded w-48" />
+          <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-64" />
+          <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-24" />
+          <div className="h-9 bg-gray-200 dark:bg-slate-700 rounded w-24" />
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -39,7 +39,7 @@
   input,
   textarea,
   select {
-    @apply bg-white text-gray-900 border-gray-300 transition-colors duration-200;
+    @apply border bg-white text-gray-900 border-gray-300 transition-colors duration-200;
   }
 
   .dark input,

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,14 @@
 }
 
 @layer base {
+  html {
+    color-scheme: light;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
   body {
     @apply font-sans antialiased bg-gray-50 text-gray-900 transition-colors duration-300;
     margin: 0;
@@ -26,5 +34,27 @@
   
   .dark body {
     @apply bg-slate-900 text-gray-100;
+  }
+
+  input,
+  textarea,
+  select {
+    @apply bg-white text-gray-900 border-gray-300 transition-colors duration-200;
+  }
+
+  .dark input,
+  .dark textarea,
+  .dark select {
+    @apply bg-slate-900 text-gray-100 border-slate-600;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    @apply text-gray-400;
+  }
+
+  .dark input::placeholder,
+  .dark textarea::placeholder {
+    @apply text-gray-500;
   }
 }

--- a/src/utils/uiStyles.ts
+++ b/src/utils/uiStyles.ts
@@ -5,16 +5,26 @@ export const UI_STYLES = {
 
   // Secondary button (smaller, no shadow)
   secondaryButton: 'px-4 py-2.5 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors',
+  secondaryButtonNeutral: 'px-4 py-2.5 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors',
+  backButton: 'px-6 py-3 rounded-lg font-medium transition-colors bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-slate-600',
 
   // Tag/badge styles
-  tag: 'bg-emerald-50 text-emerald-700 rounded-full text-sm font-medium',
-  tagWithPadding: 'px-3 py-1 bg-emerald-50 text-emerald-700 rounded-full text-sm font-medium',
+  tag: 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm font-medium',
+  tagWithPadding: 'px-3 py-1 bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-sm font-medium',
 
   // Add button (for forms)
-  addButton: 'px-3 py-1.5 text-sm bg-emerald-50 text-emerald-700 rounded-lg hover:bg-emerald-100 transition-colors flex items-center space-x-1',
+  addButton: 'px-3 py-1.5 text-sm bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-lg hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors flex items-center space-x-1',
 
   // Focus ring for form inputs
   focusRing: 'focus:ring-2 focus:ring-emerald-500 focus:border-transparent',
+
+  // Shared surfaces and typography
+  surfaceCard: 'bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-slate-700',
+  heading: 'text-gray-900 dark:text-gray-100',
+  mutedText: 'text-gray-600 dark:text-gray-300',
+  label: 'text-sm font-semibold text-gray-700 dark:text-gray-200',
+  input: 'w-full px-4 py-3 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition-colors',
+  inputError: 'w-full px-4 py-3 border border-red-500 dark:border-red-500/70 rounded-lg bg-red-50/50 dark:bg-red-950/20 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-colors',
 
   // Container spacing
   containerSpacing: 'p-6 sm:p-8',

--- a/src/utils/uiStyles.ts
+++ b/src/utils/uiStyles.ts
@@ -23,8 +23,8 @@ export const UI_STYLES = {
   heading: 'text-gray-900 dark:text-gray-100',
   mutedText: 'text-gray-600 dark:text-gray-300',
   label: 'text-sm font-semibold text-gray-700 dark:text-gray-200',
-  input: 'w-full px-4 py-3 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition-colors',
-  inputError: 'w-full px-4 py-3 border border-red-500 dark:border-red-500/70 rounded-lg bg-red-50/50 dark:bg-red-950/20 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-colors',
+  input: 'w-full px-4 py-3 border border-gray-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition-colors',
+  inputError: 'w-full px-4 py-3 border border-red-500 dark:border-red-500/70 rounded-lg bg-red-50/50 dark:bg-red-950/20 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-colors',
 
   // Container spacing
   containerSpacing: 'p-6 sm:p-8',


### PR DESCRIPTION
## Summary
- normalize shared dark theme primitives and root theme application
- update dashboard, recipe, auth, profile, community, and help surfaces to use readable dark backgrounds and text
- cover remaining dialogs, empty states, alerts, cards, and form controls that were still light-only

## Validation
- npm run build
- npm run test -- --run src/components/Dashboard.test.tsx src/features/recipes/RecipeDetail.test.tsx src/features/recipes/SavedRecipesPage.test.tsx src/features/users/FollowListModal.test.tsx src/features/auth/components/__tests__/AuthFormInput.test.tsx src/features/auth/components/__tests__/ErrorAlert.test.tsx

## Notes
- npm run lint still reports pre-existing repo issues outside the dark-mode styling changes