### PR TITLE
fix: add AI suggestions for tags and dietary restrictions

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -394,6 +394,7 @@ describe('SimpleCreateRecipe', () => {
 
 describe('AI Enhancement', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     setDefaultAuthMock()
   })
 
@@ -419,6 +420,57 @@ describe('AI Enhancement', () => {
     await waitFor(() => {
       expect(screen.getByRole('region', { name: /AI field suggestions/i })).toBeInTheDocument()
     })
+  })
+
+  it('includes dietary restrictions in AI assist requests for quick entry', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({ data: { suggestions: [] } } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.click(screen.getByRole('button', { name: /Tags & Dietary/i }))
+    fireEvent.change(screen.getByPlaceholderText(/e.g., 'vegan', 'gluten-free', 'nut-free'/i), {
+      target: { value: 'vegan' },
+    })
+    fireEvent.keyDown(screen.getByPlaceholderText(/e.g., 'vegan', 'gluten-free', 'nut-free'/i), {
+      key: 'Enter',
+      code: 'Enter',
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() => {
+      expect(postWithAuth).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ dietaryRestrictions: ['vegan'] })
+      )
+    })
+  })
+
+  it('applies dietary restriction suggestions in quick entry mode', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            field: 'dietaryRestrictions',
+            suggestedValue: 'gluten-free, dairy-free',
+            reason: 'Matches the ingredients',
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.click(screen.getByRole('button', { name: /Tags & Dietary/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Apply AI suggestion for Dietary Restrictions/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply AI suggestion for Dietary Restrictions/i }))
+
+    expect(screen.getByText('gluten-free')).toBeInTheDocument()
+    expect(screen.getByText('dairy-free')).toBeInTheDocument()
   })
 
   it('saves accepted AI nutrition estimates with the recipe', async () => {

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -9,7 +9,7 @@ import { UI_STYLES } from '../../utils/uiStyles'
 import { clampedNumericHandler } from '../../utils/formUtils'
 import { useSimpleCreateSections } from './hooks/useSimpleCreateSections'
 import { useAISuggestions } from './hooks/useAISuggestions'
-import type { StringFieldKey } from './hooks/useAISuggestions'
+import type { SuggestibleFieldKey, SuggestibleFieldValue } from './hooks/useAISuggestions'
 import { AISuggestionPanel } from './components/AISuggestionPanel'
 import { FieldAIEnhanceButton } from './components/FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './components/FieldAISuggestionChip'
@@ -196,8 +196,26 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     form.dietaryRestrictions,
   ])
 
-  const handleEnhanceField = useCallback((field: string, currentValue: string) => {
-    fetchFieldSuggestion(field as StringFieldKey, currentValue, {
+  const previousSuggestionValues = useMemo<Record<string, unknown>>(() => ({
+    recipeName: form.title,
+    description: form.description,
+    prepTime: form.prepTime,
+    cookTime: form.cookTime,
+    servings: form.servings,
+    tags: form.tags,
+    dietaryRestrictions: form.dietaryRestrictions,
+  }), [
+    form.title,
+    form.description,
+    form.prepTime,
+    form.cookTime,
+    form.servings,
+    form.tags,
+    form.dietaryRestrictions,
+  ])
+
+  const handleEnhanceField = useCallback(<K extends SuggestibleFieldKey>(field: K, currentValue: SuggestibleFieldValue<K>) => {
+    fetchFieldSuggestion(field, currentValue, {
       recipeName: form.title,
       description: form.description,
       tags: form.tags.length > 0 ? form.tags : undefined,
@@ -219,11 +237,11 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
 
   const handleApplyFieldSuggestion = useCallback((field: string, value: string) => {
     const setter = fieldSetters[field]
-    const previous = currentValues[field] ?? ''
+    const previous = previousSuggestionValues[field] ?? ''
     if (setter) {
       applySuggestion(field, () => setter(value), previous)
     }
-  }, [fieldSetters, currentValues, applySuggestion])
+  }, [fieldSetters, previousSuggestionValues, applySuggestion])
 
   const handleEnhanceWithAI = () => {
     fetchSuggestions(buildSuggestionRequest())
@@ -237,12 +255,13 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
   const handleUndo = useCallback(() => {
     const result = undoLastAIChange()
     if (!result) return
-    if (result.field === 'tags') {
-      form.setTags(normalizeSuggestionListValue(result.previousValue))
-      return
-    }
-    if (result.field === 'dietaryRestrictions') {
-      form.setDietaryRestrictions(normalizeSuggestionListValue(result.previousValue))
+    const listFieldSetter =
+      {
+        tags: form.setTags,
+        dietaryRestrictions: form.setDietaryRestrictions,
+      }[result.field]
+    if (listFieldSetter) {
+      listFieldSetter(normalizeSuggestionListValue(result.previousValue))
       return
     }
     const setter = fieldSetters[result.field]
@@ -810,7 +829,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     field="tags"
                     currentValue={stringifySuggestionList(form.tags)}
                     status={fieldStatus.get('tags') ?? 'idle'}
-                    onEnhance={() => handleEnhanceField('tags', stringifySuggestionList(form.tags))}
+                    onEnhance={() => handleEnhanceField('tags', form.tags)}
                   />
                 </div>
                 <div className="flex items-center space-x-2">
@@ -879,12 +898,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     field="dietaryRestrictions"
                     currentValue={stringifySuggestionList(form.dietaryRestrictions)}
                     status={fieldStatus.get('dietaryRestrictions') ?? 'idle'}
-                    onEnhance={() =>
-                      handleEnhanceField(
-                        'dietaryRestrictions',
-                        stringifySuggestionList(form.dietaryRestrictions)
-                      )
-                    }
+                    onEnhance={() => handleEnhanceField('dietaryRestrictions', form.dietaryRestrictions)}
                   />
                 </div>
                 <div className="flex items-center space-x-2">

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -24,6 +24,11 @@ import type { Recipe } from '../../types/nutrition'
 import { mapEstimateToNutritionalInfo, useNutritionEstimate } from './hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './components/NutritionEstimatePanel'
 import NutritionFacts from '../../components/NutritionFacts'
+import {
+  normalizeSuggestionListValue,
+  parseSuggestedList,
+  stringifySuggestionList,
+} from './utils/aiSuggestionValueUtils'
 
 type RecipeFormInitialState = Parameters<typeof useRecipeForm>[0]
 
@@ -148,6 +153,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     cookTime: form.cookTime || undefined,
     servings: form.servings || undefined,
     tags: form.tags.length > 0 ? form.tags : undefined,
+    dietaryRestrictions: form.dietaryRestrictions.length > 0 ? form.dietaryRestrictions : undefined,
     ingredients: form.ingredients.filter(i => i.item.trim()).map(i =>
       [i.quantity, i.unit, i.item].filter(Boolean).join(' ')
     ),
@@ -160,7 +166,17 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     prepTime: form.setPrepTime,
     cookTime: form.setCookTime,
     servings: form.setServings,
-  }), [form.setTitle, form.setDescription, form.setPrepTime, form.setCookTime, form.setServings])
+    tags: (value: string) => form.setTags(parseSuggestedList(value)),
+    dietaryRestrictions: (value: string) => form.setDietaryRestrictions(parseSuggestedList(value)),
+  }), [
+    form.setTitle,
+    form.setDescription,
+    form.setPrepTime,
+    form.setCookTime,
+    form.setServings,
+    form.setTags,
+    form.setDietaryRestrictions,
+  ])
 
   const currentValues: Partial<Record<string, string>> = useMemo(() => ({
     recipeName: form.title,
@@ -168,14 +184,38 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     prepTime: form.prepTime,
     cookTime: form.cookTime,
     servings: form.servings,
-  }), [form.title, form.description, form.prepTime, form.cookTime, form.servings])
+    tags: stringifySuggestionList(form.tags),
+    dietaryRestrictions: stringifySuggestionList(form.dietaryRestrictions),
+  }), [
+    form.title,
+    form.description,
+    form.prepTime,
+    form.cookTime,
+    form.servings,
+    form.tags,
+    form.dietaryRestrictions,
+  ])
 
   const handleEnhanceField = useCallback((field: string, currentValue: string) => {
     fetchFieldSuggestion(field as StringFieldKey, currentValue, {
       recipeName: form.title,
       description: form.description,
+      tags: form.tags.length > 0 ? form.tags : undefined,
+      dietaryRestrictions: form.dietaryRestrictions.length > 0 ? form.dietaryRestrictions : undefined,
+      ingredients: form.ingredients.filter(i => i.item.trim()).map(i =>
+        [i.quantity, i.unit, i.item].filter(Boolean).join(' ')
+      ),
+      instructions: form.instructions.filter(i => i.trim()),
     })
-  }, [fetchFieldSuggestion, form.title, form.description])
+  }, [
+    fetchFieldSuggestion,
+    form.title,
+    form.description,
+    form.tags,
+    form.dietaryRestrictions,
+    form.ingredients,
+    form.instructions,
+  ])
 
   const handleApplyFieldSuggestion = useCallback((field: string, value: string) => {
     const setter = fieldSetters[field]
@@ -197,9 +237,17 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
   const handleUndo = useCallback(() => {
     const result = undoLastAIChange()
     if (!result) return
+    if (result.field === 'tags') {
+      form.setTags(normalizeSuggestionListValue(result.previousValue))
+      return
+    }
+    if (result.field === 'dietaryRestrictions') {
+      form.setDietaryRestrictions(normalizeSuggestionListValue(result.previousValue))
+      return
+    }
     const setter = fieldSetters[result.field]
     if (setter) setter(String(result.previousValue ?? ''))
-  }, [undoLastAIChange, fieldSetters])
+  }, [undoLastAIChange, fieldSetters, form.setTags, form.setDietaryRestrictions])
   const hasIngredients = form.ingredients.some((ingredient) => ingredient.item.trim())
   const hasSavedNutrition = Boolean(activeRecipeOverrides.nutritionalInfo?.perServing)
 
@@ -754,9 +802,17 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
             <div className="space-y-6">
               {/* Tags */}
               <div>
-                <label className="block text-sm font-semibold text-gray-700 mb-2">
-                  Tags (Optional)
-                </label>
+                <div className="flex items-center gap-1.5 mb-2">
+                  <label className="block text-sm font-semibold text-gray-700">
+                    Tags (Optional)
+                  </label>
+                  <FieldAIEnhanceButton
+                    field="tags"
+                    currentValue={stringifySuggestionList(form.tags)}
+                    status={fieldStatus.get('tags') ?? 'idle'}
+                    onEnhance={() => handleEnhanceField('tags', stringifySuggestionList(form.tags))}
+                  />
+                </div>
                 <div className="flex items-center space-x-2">
                   <input
                     type="text"
@@ -799,13 +855,38 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     ))}
                   </div>
                 )}
+                {(() => {
+                  const s = visibleSuggestions.find(x => x.field === 'tags')
+                  return s ? (
+                    <FieldAISuggestionChip
+                      field="tags"
+                      suggestion={s.suggestedValue}
+                      currentValue={stringifySuggestionList(form.tags)}
+                      onApply={() => handleApplyFieldSuggestion('tags', s.suggestedValue)}
+                      onDismiss={() => dismissSuggestion('tags')}
+                    />
+                  ) : null
+                })()}
               </div>
 
               {/* Dietary restrictions */}
               <div>
-                <label className="block text-sm font-semibold text-gray-700 mb-2">
-                  Dietary Restrictions (Optional)
-                </label>
+                <div className="flex items-center gap-1.5 mb-2">
+                  <label className="block text-sm font-semibold text-gray-700">
+                    Dietary Restrictions (Optional)
+                  </label>
+                  <FieldAIEnhanceButton
+                    field="dietaryRestrictions"
+                    currentValue={stringifySuggestionList(form.dietaryRestrictions)}
+                    status={fieldStatus.get('dietaryRestrictions') ?? 'idle'}
+                    onEnhance={() =>
+                      handleEnhanceField(
+                        'dietaryRestrictions',
+                        stringifySuggestionList(form.dietaryRestrictions)
+                      )
+                    }
+                  />
+                </div>
                 <div className="flex items-center space-x-2">
                   <input
                     type="text"
@@ -848,6 +929,18 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     ))}
                   </div>
                 )}
+                {(() => {
+                  const s = visibleSuggestions.find(x => x.field === 'dietaryRestrictions')
+                  return s ? (
+                    <FieldAISuggestionChip
+                      field="dietaryRestrictions"
+                      suggestion={s.suggestedValue}
+                      currentValue={stringifySuggestionList(form.dietaryRestrictions)}
+                      onApply={() => handleApplyFieldSuggestion('dietaryRestrictions', s.suggestedValue)}
+                      onDismiss={() => dismissSuggestion('dietaryRestrictions')}
+                    />
+                  ) : null
+                })()}
               </div>
             </div>
           </CollapsibleSection>

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -15,6 +15,11 @@ import { AIBadge } from './AIBadge'
 import { mapEstimateToNutritionalInfo, useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
 import { AI_BUTTON_CLASS } from './aiStyles'
+import {
+  normalizeSuggestionListValue,
+  parseSuggestedList,
+  stringifySuggestionList,
+} from '../utils/aiSuggestionValueUtils'
 import type { Ingredient, Recipe } from '../../../types/nutrition'
 import NutritionFacts from '../../../components/NutritionFacts'
 import { UI_STYLES } from '../../../utils/uiStyles'
@@ -58,11 +63,13 @@ interface RecipeFormLayoutProps {
   updateInstruction: (index: number, value: string) => void
   removeInstruction: (index: number) => void
   tags: string[]
+  setTags: (value: string[]) => void
   tagInput: string
   setTagInput: (value: string) => void
   addTag: () => void
   removeTag: (index: number) => void
   dietaryRestrictions: string[]
+  setDietaryRestrictions: (value: string[]) => void
   dietaryInput: string
   setDietaryInput: (value: string) => void
   addDietaryRestriction: () => void
@@ -126,11 +133,13 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
   updateInstruction,
   removeInstruction,
   tags,
+  setTags,
   tagInput,
   setTagInput,
   addTag,
   removeTag,
   dietaryRestrictions,
+  setDietaryRestrictions,
   dietaryInput,
   setDietaryInput,
   addDietaryRestriction,
@@ -313,12 +322,24 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     prepTime: setPrepTime,
     cookTime: setCookTime,
     servings: setServings,
-  }), [setTitle, setDescription, setPrepTime, setCookTime, setServings])
+    tags: (value: string) => setTags(parseSuggestedList(value)),
+    dietaryRestrictions: (value: string) => setDietaryRestrictions(parseSuggestedList(value)),
+  }), [setTitle, setDescription, setPrepTime, setCookTime, setServings, setTags, setDietaryRestrictions])
 
   // Internal undo handler: uses the local audit trail (from RecipeFormLayout's own hook)
   const handleLocalUndo = useCallback(() => {
     const result = localUndoLastAIChange()
     if (!result) return
+    if (result.field === 'tags') {
+      setTags(normalizeSuggestionListValue(result.previousValue))
+      if (onUndoLastAI) onUndoLastAI()
+      return
+    }
+    if (result.field === 'dietaryRestrictions') {
+      setDietaryRestrictions(normalizeSuggestionListValue(result.previousValue))
+      if (onUndoLastAI) onUndoLastAI()
+      return
+    }
     const setterMap: Record<string, (v: string) => void> = {
       recipeName: setTitle,
       description: setDescription,
@@ -330,14 +351,20 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     if (setter) setter(String(result.previousValue ?? ''))
     // Also invoke the parent's undo handler if provided (for synchronisation)
     if (onUndoLastAI) onUndoLastAI()
-  }, [localUndoLastAIChange, setTitle, setDescription, setPrepTime, setCookTime, setServings, onUndoLastAI])
+  }, [localUndoLastAIChange, setTitle, setDescription, setPrepTime, setCookTime, setServings, setTags, setDietaryRestrictions, onUndoLastAI])
 
   const handleEnhanceField = useCallback((field: string, currentValue: string) => {
-    fetchFieldSuggestion(field as import('../hooks/useAISuggestions').StringFieldKey, currentValue, {
+    fetchFieldSuggestion(field as import('../hooks/useAISuggestions').SuggestibleFieldKey, currentValue, {
       recipeName: title,
       description: description,
+      tags: tags.length > 0 ? tags : undefined,
+      dietaryRestrictions: dietaryRestrictions.length > 0 ? dietaryRestrictions : undefined,
+      ingredients: ingredients.filter(i => i.item.trim()).map(i =>
+        [i.quantity, i.unit, i.item].filter(Boolean).join(' ')
+      ),
+      instructions: instructions.filter(i => i.trim()),
     })
-  }, [fetchFieldSuggestion, title, description])
+  }, [fetchFieldSuggestion, title, description, tags, dietaryRestrictions, ingredients, instructions])
 
   const handleApplyFieldSuggestion = useCallback((field: string, value: string) => {
     const setter = fieldSetters[field]
@@ -347,11 +374,13 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
       prepTime,
       cookTime,
       servings,
+      tags,
+      dietaryRestrictions,
     }[field] ?? ''
     if (setter) {
       applySuggestion(field, () => setter(value), previousValue)
     }
-  }, [fieldSetters, title, description, prepTime, cookTime, servings, applySuggestion])
+  }, [fieldSetters, title, description, prepTime, cookTime, servings, tags, dietaryRestrictions, applySuggestion])
 
   // Shared request builder for AI suggestions
   const buildSuggestionRequest = () => ({
@@ -361,6 +390,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     cookTime: cookTime || undefined,
     servings: servings || undefined,
     tags: tags.length > 0 ? tags : undefined,
+    dietaryRestrictions: dietaryRestrictions.length > 0 ? dietaryRestrictions : undefined,
     ingredients: ingredients.filter(i => i.item.trim()).map(i =>
       [i.quantity, i.unit, i.item].filter(Boolean).join(' ')
     ),
@@ -442,7 +472,8 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
             prepTime,
             cookTime,
             servings,
-            tags: tags.join(', '),
+            tags: stringifySuggestionList(tags),
+            dietaryRestrictions: stringifySuggestionList(dietaryRestrictions),
           }}
           onRetry={handleRetrySuggestions}
           currentStep={currentStep}

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -15,6 +15,7 @@ import { AIBadge } from './AIBadge'
 import { mapEstimateToNutritionalInfo, useNutritionEstimate } from '../hooks/useNutritionEstimate'
 import { NutritionEstimatePanel } from './NutritionEstimatePanel'
 import { AI_BUTTON_CLASS } from './aiStyles'
+import type { SuggestibleFieldKey, SuggestibleFieldValue } from '../hooks/useAISuggestions'
 import {
   normalizeSuggestionListValue,
   parseSuggestedList,
@@ -326,17 +327,22 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     dietaryRestrictions: (value: string) => setDietaryRestrictions(parseSuggestedList(value)),
   }), [setTitle, setDescription, setPrepTime, setCookTime, setServings, setTags, setDietaryRestrictions])
 
+  const listFieldUndoSetters = useMemo(
+    () => ({
+      tags: setTags,
+      dietaryRestrictions: setDietaryRestrictions,
+    }),
+    [setTags, setDietaryRestrictions]
+  )
+
   // Internal undo handler: uses the local audit trail (from RecipeFormLayout's own hook)
   const handleLocalUndo = useCallback(() => {
     const result = localUndoLastAIChange()
     if (!result) return
-    if (result.field === 'tags') {
-      setTags(normalizeSuggestionListValue(result.previousValue))
-      if (onUndoLastAI) onUndoLastAI()
-      return
-    }
-    if (result.field === 'dietaryRestrictions') {
-      setDietaryRestrictions(normalizeSuggestionListValue(result.previousValue))
+    const listFieldSetter =
+      listFieldUndoSetters[result.field as keyof typeof listFieldUndoSetters]
+    if (listFieldSetter) {
+      listFieldSetter(normalizeSuggestionListValue(result.previousValue))
       if (onUndoLastAI) onUndoLastAI()
       return
     }
@@ -351,10 +357,10 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     if (setter) setter(String(result.previousValue ?? ''))
     // Also invoke the parent's undo handler if provided (for synchronisation)
     if (onUndoLastAI) onUndoLastAI()
-  }, [localUndoLastAIChange, setTitle, setDescription, setPrepTime, setCookTime, setServings, setTags, setDietaryRestrictions, onUndoLastAI])
+  }, [localUndoLastAIChange, listFieldUndoSetters, setTitle, setDescription, setPrepTime, setCookTime, setServings, onUndoLastAI])
 
-  const handleEnhanceField = useCallback((field: string, currentValue: string) => {
-    fetchFieldSuggestion(field as import('../hooks/useAISuggestions').SuggestibleFieldKey, currentValue, {
+  const handleEnhanceField = useCallback(<K extends SuggestibleFieldKey>(field: K, currentValue: SuggestibleFieldValue<K>) => {
+    fetchFieldSuggestion(field, currentValue, {
       recipeName: title,
       description: description,
       tags: tags.length > 0 ? tags : undefined,

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -7,7 +7,12 @@ import type { StepRefinementState, RefinementLoadingState } from '../hooks/useIn
 import { InstructionDiffView } from './InstructionDiffView'
 import { FieldAIEnhanceButton } from './FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './FieldAISuggestionChip'
-import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
+import type {
+  FieldSuggestion,
+  SuggestionStatus,
+  SuggestibleFieldKey,
+  SuggestibleFieldValue,
+} from '../hooks/useAISuggestions'
 import { AISpinnerIcon } from './AISpinnerIcon'
 import { AIBadge } from './AIBadge'
 import { AI_BUTTON_CLASS, AI_BUTTON_COMPACT_CLASS, AI_STEP_ACTION_BUTTON_CLASS } from './aiStyles'
@@ -66,7 +71,7 @@ interface RecipeFormStepsProps {
   onApplyNormalization?: (index: number) => void
   onDismissNormalization?: (index: number) => void
   // Per-field AI enhance
-  onEnhanceField?: (field: string, currentValue: string) => void
+  onEnhanceField?: <K extends SuggestibleFieldKey>(field: K, currentValue: SuggestibleFieldValue<K>) => void
   fieldStatus?: Map<string, SuggestionStatus>
   fieldSuggestions?: FieldSuggestion[]
   onApplyFieldSuggestion?: (field: string, value: string) => void
@@ -594,7 +599,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="tags"
                   currentValue={stringifySuggestionList(tags)}
                   status={getFieldStatus('tags')}
-                  onEnhance={() => onEnhanceField('tags', stringifySuggestionList(tags))}
+                  onEnhance={() => onEnhanceField('tags', tags)}
                 />
               )}
             </div>
@@ -665,9 +670,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="dietaryRestrictions"
                   currentValue={stringifySuggestionList(dietaryRestrictions)}
                   status={getFieldStatus('dietaryRestrictions')}
-                  onEnhance={() =>
-                    onEnhanceField('dietaryRestrictions', stringifySuggestionList(dietaryRestrictions))
-                  }
+                  onEnhance={() => onEnhanceField('dietaryRestrictions', dietaryRestrictions)}
                 />
               )}
             </div>

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -11,6 +11,7 @@ import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestion
 import { AISpinnerIcon } from './AISpinnerIcon'
 import { AIBadge } from './AIBadge'
 import { AI_BUTTON_CLASS, AI_BUTTON_COMPACT_CLASS, AI_STEP_ACTION_BUTTON_CLASS } from './aiStyles'
+import { stringifySuggestionList } from '../utils/aiSuggestionValueUtils'
 
 
 interface RecipeFormStepsProps {
@@ -584,9 +585,19 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
 
           {/* Tags Section */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">
-              Tags (Optional)
-            </h3>
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-lg font-semibold text-gray-900">
+                Tags (Optional)
+              </h3>
+              {onEnhanceField && (
+                <FieldAIEnhanceButton
+                  field="tags"
+                  currentValue={stringifySuggestionList(tags)}
+                  status={getFieldStatus('tags')}
+                  onEnhance={() => onEnhanceField('tags', stringifySuggestionList(tags))}
+                />
+              )}
+            </div>
 
             <div className="flex items-center space-x-2">
               <input
@@ -630,12 +641,36 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 ))}
               </div>
             )}
+            {onEnhanceField && (() => {
+              const s = getFieldSuggestion('tags')
+              return s ? (
+                <FieldAISuggestionChip
+                  field="tags"
+                  suggestion={s.suggestedValue}
+                  currentValue={stringifySuggestionList(tags)}
+                  onApply={() => onApplyFieldSuggestion?.('tags', s.suggestedValue)}
+                  onDismiss={() => onDismissFieldSuggestion?.('tags')}
+                />
+              ) : null
+            })()}
           </div>
           {/* Dietary Restrictions Section */}
           <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-gray-900">
-              Dietary Restrictions (Optional)
-            </h3>
+            <div className="flex items-center gap-1.5">
+              <h3 className="text-lg font-semibold text-gray-900">
+                Dietary Restrictions (Optional)
+              </h3>
+              {onEnhanceField && (
+                <FieldAIEnhanceButton
+                  field="dietaryRestrictions"
+                  currentValue={stringifySuggestionList(dietaryRestrictions)}
+                  status={getFieldStatus('dietaryRestrictions')}
+                  onEnhance={() =>
+                    onEnhanceField('dietaryRestrictions', stringifySuggestionList(dietaryRestrictions))
+                  }
+                />
+              )}
+            </div>
 
             <div className="flex items-center space-x-2">
               <input
@@ -679,6 +714,18 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 ))}
               </div>
             )}
+            {onEnhanceField && (() => {
+              const s = getFieldSuggestion('dietaryRestrictions')
+              return s ? (
+                <FieldAISuggestionChip
+                  field="dietaryRestrictions"
+                  suggestion={s.suggestedValue}
+                  currentValue={stringifySuggestionList(dietaryRestrictions)}
+                  onApply={() => onApplyFieldSuggestion?.('dietaryRestrictions', s.suggestedValue)}
+                  onDismiss={() => onDismissFieldSuggestion?.('dietaryRestrictions')}
+                />
+              ) : null
+            })()}
           </div>
         </div>
       )}

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -57,11 +57,13 @@ function makeProps(overrides: Partial<ComponentProps<typeof RecipeFormLayout>> =
     updateInstruction: vi.fn(),
     removeInstruction: vi.fn(),
     tags: [],
+    setTags: vi.fn(),
     tagInput: '',
     setTagInput: vi.fn(),
     addTag: vi.fn(),
     removeTag: vi.fn(),
     dietaryRestrictions: [],
+    setDietaryRestrictions: vi.fn(),
     dietaryInput: '',
     setDietaryInput: vi.fn(),
     addDietaryRestriction: vi.fn(),
@@ -141,6 +143,26 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     )
   })
 
+  it('includes dietary restrictions in the AI assist request payload', async () => {
+    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+
+    renderWithRouter(makeProps({
+      title: 'Pasta',
+      tags: ['quick'],
+      dietaryRestrictions: ['vegetarian'],
+    }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() => expect(mockPostWithAuth).toHaveBeenCalledOnce())
+    expect(mockPostWithAuth).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        tags: ['quick'],
+        dietaryRestrictions: ['vegetarian'],
+      })
+    )
+  })
+
   it('shows the suggestion panel only after the button is clicked', async () => {
     mockPostWithAuth.mockResolvedValueOnce({
       data: {
@@ -212,6 +234,37 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Undo: Description/i })).toBeInTheDocument()
     )
+  })
+
+  it('applies dietary restriction suggestions as list values', async () => {
+    const setDietaryRestrictions = vi.fn()
+    mockPostWithAuth.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            field: 'dietaryRestrictions',
+            suggestedValue: 'gluten-free, dairy-free',
+            reason: 'Good fit',
+          },
+        ],
+      },
+    } as any)
+
+    renderWithRouter(makeProps({
+      currentStep: 4,
+      title: 'Soup',
+      ingredients: [{ quantity: '1', unit: 'cup', item: 'broth' }],
+      instructions: ['Simmer'],
+      setDietaryRestrictions,
+    }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Apply AI suggestion for Dietary Restrictions/i })).toBeInTheDocument()
+    )
+    fireEvent.click(screen.getByRole('button', { name: /Apply AI suggestion for Dietary Restrictions/i }))
+
+    expect(setDietaryRestrictions).toHaveBeenCalledWith(['gluten-free', 'dairy-free'])
   })
 })
 

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -231,6 +231,44 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
     expect(onDismiss).toHaveBeenCalledWith('recipeName')
   })
+
+  it('shows AI enhance buttons for tags and dietary restrictions on step 4', () => {
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          currentStep: 4,
+          tags: ['quick'],
+          dietaryRestrictions: ['vegetarian'],
+          onEnhanceField: vi.fn(),
+        })}
+      />
+    )
+
+    expect(screen.getAllByRole('button', { name: /complete with ai|enhance with ai/i }).length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText(/Tags \(Optional\)/i)).toBeInTheDocument()
+    expect(screen.getByText(/Dietary Restrictions \(Optional\)/i)).toBeInTheDocument()
+  })
+
+  it('renders dietary restriction suggestion chip on step 4 and applies it', () => {
+    const onApply = vi.fn()
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          currentStep: 4,
+          onEnhanceField: vi.fn(),
+          fieldSuggestions: [
+            { field: 'dietaryRestrictions', suggestedValue: 'gluten-free, dairy-free', reason: 'Matches ingredients' },
+          ],
+          onApplyFieldSuggestion: onApply,
+          onDismissFieldSuggestion: vi.fn(),
+        })}
+      />
+    )
+
+    expect(screen.getByText('gluten-free, dairy-free')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }))
+    expect(onApply).toHaveBeenCalledWith('dietaryRestrictions', 'gluten-free, dairy-free')
+  })
 })
 
 describe('RecipeFormSteps — AI image generation (issue #41)', () => {

--- a/src/features/recipes/constants/aiConstants.ts
+++ b/src/features/recipes/constants/aiConstants.ts
@@ -7,10 +7,11 @@ export const FIELD_LABELS: Record<string, string> = {
   cookTime: 'Cook Time (min)',
   servings: 'Servings',
   tags: 'Tags',
+  dietaryRestrictions: 'Dietary Restrictions',
 };
 
 /** Maps form step numbers to the field names shown on that step. */
 export const STEP_FIELDS: Record<number, string[]> = {
   1: ['recipeName', 'description'],
-  4: ['prepTime', 'cookTime', 'servings', 'tags'],
+  4: ['prepTime', 'cookTime', 'servings', 'tags', 'dietaryRestrictions'],
 };

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -21,14 +21,16 @@ export interface FieldSuggestionRequest {
   cookTime?: string
   servings?: string
   tags?: string[]
+  dietaryRestrictions?: string[]
   ingredients?: string[]
   instructions?: string[]
 }
 
 export type SuggestionStatus = 'idle' | 'loading' | 'success' | 'error'
 
-/** String-valued keys of FieldSuggestionRequest (excludes array-typed fields like tags/ingredients/instructions). */
-export type StringFieldKey = Exclude<keyof FieldSuggestionRequest, 'tags' | 'ingredients' | 'instructions'>
+/** Suggestible keys of FieldSuggestionRequest (excludes context-only array fields like ingredients/instructions). */
+export type SuggestibleFieldKey = Exclude<keyof FieldSuggestionRequest, 'ingredients' | 'instructions'>
+export type StringFieldKey = SuggestibleFieldKey
 
 interface UseAISuggestionsReturn {
   suggestions: FieldSuggestion[]
@@ -36,9 +38,13 @@ interface UseAISuggestionsReturn {
   status: SuggestionStatus
   error: string | null
   fetchSuggestions: (request: FieldSuggestionRequest) => Promise<void>
-  fetchFieldSuggestion: (field: StringFieldKey, currentValue: string, context?: Partial<FieldSuggestionRequest>) => Promise<void>
+  fetchFieldSuggestion: (
+    field: SuggestibleFieldKey,
+    currentValue: string | string[],
+    context?: Partial<FieldSuggestionRequest>
+  ) => Promise<void>
   fieldStatus: Map<string, SuggestionStatus>
-  applySuggestion: (field: string, applyFn: (value: string) => void, previousValue: string) => void
+  applySuggestion: (field: string, applyFn: (value: string) => void, previousValue: unknown) => void
   dismissSuggestion: (field: string) => void
   visibleSuggestions: FieldSuggestion[]
   // Audit trail
@@ -108,8 +114,8 @@ export function useAISuggestions(): UseAISuggestionsReturn {
   }, [recordSuggestion])
 
   const fetchFieldSuggestion = useCallback(async (
-    field: StringFieldKey,
-    currentValue: string,
+    field: SuggestibleFieldKey,
+    currentValue: string | string[],
     context?: Partial<FieldSuggestionRequest>
   ) => {
     setFieldStatus(prev => new Map(prev).set(field, 'loading'))
@@ -147,7 +153,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     }
   }, [recordSuggestion])
 
-  const applySuggestion = useCallback((field: string, applyFn: (value: string) => void, previousValue: string) => {
+  const applySuggestion = useCallback((field: string, applyFn: (value: string) => void, previousValue: unknown) => {
     const suggestion = suggestions.find(s => s.field === field)
     if (!suggestion) return
 

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -30,7 +30,10 @@ export type SuggestionStatus = 'idle' | 'loading' | 'success' | 'error'
 
 /** Suggestible keys of FieldSuggestionRequest (excludes context-only array fields like ingredients/instructions). */
 export type SuggestibleFieldKey = Exclude<keyof FieldSuggestionRequest, 'ingredients' | 'instructions'>
-export type StringFieldKey = SuggestibleFieldKey
+export type ListSuggestibleFieldKey = Extract<SuggestibleFieldKey, 'tags' | 'dietaryRestrictions'>
+export type ScalarSuggestibleFieldKey = Exclude<SuggestibleFieldKey, ListSuggestibleFieldKey>
+export type SuggestibleFieldValue<K extends SuggestibleFieldKey = SuggestibleFieldKey> =
+  K extends ListSuggestibleFieldKey ? string[] : string
 
 interface UseAISuggestionsReturn {
   suggestions: FieldSuggestion[]
@@ -38,9 +41,9 @@ interface UseAISuggestionsReturn {
   status: SuggestionStatus
   error: string | null
   fetchSuggestions: (request: FieldSuggestionRequest) => Promise<void>
-  fetchFieldSuggestion: (
-    field: SuggestibleFieldKey,
-    currentValue: string | string[],
+  fetchFieldSuggestion: <K extends SuggestibleFieldKey>(
+    field: K,
+    currentValue: SuggestibleFieldValue<K>,
     context?: Partial<FieldSuggestionRequest>
   ) => Promise<void>
   fieldStatus: Map<string, SuggestionStatus>
@@ -121,7 +124,16 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     setFieldStatus(prev => new Map(prev).set(field, 'loading'))
     setError(null)
 
-    const request: FieldSuggestionRequest = { ...context, [field]: currentValue }
+    const request: FieldSuggestionRequest =
+      field === 'tags' || field === 'dietaryRestrictions'
+        ? {
+            ...context,
+            [field]: Array.isArray(currentValue) ? currentValue : [],
+          }
+        : {
+            ...context,
+            [field]: typeof currentValue === 'string' ? currentValue : '',
+          }
 
     try {
       const apiBase = import.meta.env.VITE_AI_API_URL ?? import.meta.env.VITE_API_URL ?? ''

--- a/src/features/recipes/utils/aiSuggestionValueUtils.ts
+++ b/src/features/recipes/utils/aiSuggestionValueUtils.ts
@@ -1,0 +1,36 @@
+const normalizeUniqueList = (items: string[]): string[] => {
+  const seen = new Set<string>()
+
+  return items.filter((item) => {
+    const normalized = item.trim()
+    if (!normalized) return false
+
+    const key = normalized.toLowerCase()
+    if (seen.has(key)) return false
+
+    seen.add(key)
+    return true
+  })
+}
+
+export const parseSuggestedList = (value: string): string[] =>
+  normalizeUniqueList(
+    value
+      .split(/[\n,;]+/)
+      .map((item) => item.trim())
+      .filter(Boolean)
+  )
+
+export const stringifySuggestionList = (value: string[]): string => value.join(', ')
+
+export const normalizeSuggestionListValue = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return normalizeUniqueList(value.filter((item): item is string => typeof item === 'string'))
+  }
+
+  if (typeof value === 'string') {
+    return parseSuggestedList(value)
+  }
+
+  return []
+}

--- a/src/features/recipes/utils/aiSuggestionValueUtils.ts
+++ b/src/features/recipes/utils/aiSuggestionValueUtils.ts
@@ -1,16 +1,16 @@
 const normalizeUniqueList = (items: string[]): string[] => {
   const seen = new Set<string>()
-
-  return items.filter((item) => {
+  return items.reduce<string[]>((normalizedItems, item) => {
     const normalized = item.trim()
-    if (!normalized) return false
+    if (!normalized) return normalizedItems
 
     const key = normalized.toLowerCase()
-    if (seen.has(key)) return false
+    if (seen.has(key)) return normalizedItems
 
     seen.add(key)
-    return true
-  })
+    normalizedItems.push(normalized)
+    return normalizedItems
+  }, [])
 }
 
 export const parseSuggestedList = (value: string): string[] =>


### PR DESCRIPTION
## Problem
Recipe create/edit flows could use AI suggestions for scalar fields, but tags and dietary restrictions were not fully supported across the quick-entry and guided forms.

## Changes
- add AI request/apply/undo support for tag and dietary restriction suggestions
- expose per-field AI affordances for tags and dietary restrictions in both recipe forms
- add shared parsing utilities and focused test coverage for the new array-field suggestion flow

This PR is for `recipe-management-frontend` only.