### PR TITLE
fix: separate bulk and field AI suggestions

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -235,11 +235,11 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     form.instructions,
   ])
 
-  const handleApplyFieldSuggestion = useCallback((field: string, value: string) => {
-    const setter = fieldSetters[field]
-    const previous = previousSuggestionValues[field] ?? ''
+  const handleApplyFieldSuggestion = useCallback((suggestion: import('./hooks/useAISuggestions').FieldSuggestion) => {
+    const setter = fieldSetters[suggestion.field]
+    const previous = previousSuggestionValues[suggestion.field] ?? ''
     if (setter) {
-      applySuggestion(field, () => setter(value), previous)
+      applySuggestion(suggestion, () => setter(suggestion.suggestedValue), previous)
     }
   }, [fieldSetters, previousSuggestionValues, applySuggestion])
 
@@ -463,8 +463,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   field="recipeName"
                   suggestion={s.suggestedValue}
                   currentValue={form.title}
-                  onApply={() => handleApplyFieldSuggestion('recipeName', s.suggestedValue)}
-                  onDismiss={() => dismissSuggestion('recipeName')}
+                  onApply={() => handleApplyFieldSuggestion(s)}
+                  onDismiss={() => dismissSuggestion(s)}
                 />
               ) : null
             })()}
@@ -498,8 +498,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   field="description"
                   suggestion={s.suggestedValue}
                   currentValue={form.description}
-                  onApply={() => handleApplyFieldSuggestion('description', s.suggestedValue)}
-                  onDismiss={() => dismissSuggestion('description')}
+                  onApply={() => handleApplyFieldSuggestion(s)}
+                  onDismiss={() => dismissSuggestion(s)}
                 />
               ) : null
             })()}
@@ -677,8 +677,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                       field="prepTime"
                       suggestion={s.suggestedValue}
                       currentValue={form.prepTime}
-                      onApply={() => handleApplyFieldSuggestion('prepTime', s.suggestedValue)}
-                      onDismiss={() => dismissSuggestion('prepTime')}
+                      onApply={() => handleApplyFieldSuggestion(s)}
+                      onDismiss={() => dismissSuggestion(s)}
                     />
                   ) : null
                 })()}
@@ -716,8 +716,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                       field="cookTime"
                       suggestion={s.suggestedValue}
                       currentValue={form.cookTime}
-                      onApply={() => handleApplyFieldSuggestion('cookTime', s.suggestedValue)}
-                      onDismiss={() => dismissSuggestion('cookTime')}
+                      onApply={() => handleApplyFieldSuggestion(s)}
+                      onDismiss={() => dismissSuggestion(s)}
                     />
                   ) : null
                 })()}
@@ -767,8 +767,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     field="servings"
                     suggestion={s.suggestedValue}
                     currentValue={form.servings}
-                    onApply={() => handleApplyFieldSuggestion('servings', s.suggestedValue)}
-                    onDismiss={() => dismissSuggestion('servings')}
+                    onApply={() => handleApplyFieldSuggestion(s)}
+                    onDismiss={() => dismissSuggestion(s)}
                   />
                 ) : null
               })()}
@@ -891,8 +891,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                       field="tags"
                       suggestion={s.suggestedValue}
                       currentValue={stringifySuggestionList(form.tags)}
-                      onApply={() => handleApplyFieldSuggestion('tags', s.suggestedValue)}
-                      onDismiss={() => dismissSuggestion('tags')}
+                      onApply={() => handleApplyFieldSuggestion(s)}
+                      onDismiss={() => dismissSuggestion(s)}
                     />
                   ) : null
                 })()}
@@ -960,8 +960,8 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                       field="dietaryRestrictions"
                       suggestion={s.suggestedValue}
                       currentValue={stringifySuggestionList(form.dietaryRestrictions)}
-                      onApply={() => handleApplyFieldSuggestion('dietaryRestrictions', s.suggestedValue)}
-                      onDismiss={() => dismissSuggestion('dietaryRestrictions')}
+                      onApply={() => handleApplyFieldSuggestion(s)}
+                      onDismiss={() => dismissSuggestion(s)}
                     />
                   ) : null
                 })()}

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -8,7 +8,7 @@ import { COMMON_UNITS, IngredientInput } from '../../components/IngredientInput'
 import { UI_STYLES } from '../../utils/uiStyles'
 import { clampedNumericHandler } from '../../utils/formUtils'
 import { useSimpleCreateSections } from './hooks/useSimpleCreateSections'
-import { useAISuggestions } from './hooks/useAISuggestions'
+import { isFieldSuggestion, useAISuggestions } from './hooks/useAISuggestions'
 import type { SuggestibleFieldKey, SuggestibleFieldValue } from './hooks/useAISuggestions'
 import { AISuggestionPanel } from './components/AISuggestionPanel'
 import { FieldAIEnhanceButton } from './components/FieldAIEnhanceButton'
@@ -247,6 +247,16 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     fetchSuggestions(buildSuggestionRequest())
   }
 
+  const fieldVisibleSuggestions = useMemo(
+    () => visibleSuggestions.filter(isFieldSuggestion),
+    [visibleSuggestions]
+  )
+
+  const getFieldSuggestion = useCallback(
+    (field: string) => fieldVisibleSuggestions.find(suggestion => suggestion.field === field),
+    [fieldVisibleSuggestions]
+  )
+
   const lastUndoableAIField = useMemo<string | null>(() => {
     const latestEntry = auditLog[auditLog.length - 1]
     return latestEntry?.event === 'accepted' ? latestEntry.field : null
@@ -447,7 +457,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               </p>
             )}
             {(() => {
-              const s = visibleSuggestions.find(x => x.field === 'recipeName')
+              const s = getFieldSuggestion('recipeName')
               return s ? (
                 <FieldAISuggestionChip
                   field="recipeName"
@@ -482,7 +492,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
             />
             {(() => {
-              const s = visibleSuggestions.find(x => x.field === 'description')
+              const s = getFieldSuggestion('description')
               return s ? (
                 <FieldAISuggestionChip
                   field="description"
@@ -661,7 +671,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
                 {(() => {
-                  const s = visibleSuggestions.find(x => x.field === 'prepTime')
+                  const s = getFieldSuggestion('prepTime')
                   return s ? (
                     <FieldAISuggestionChip
                       field="prepTime"
@@ -700,7 +710,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
                 {(() => {
-                  const s = visibleSuggestions.find(x => x.field === 'cookTime')
+                  const s = getFieldSuggestion('cookTime')
                   return s ? (
                     <FieldAISuggestionChip
                       field="cookTime"
@@ -751,7 +761,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 className="w-full sm:w-40 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
               />
               {(() => {
-                const s = visibleSuggestions.find(x => x.field === 'servings')
+                const s = getFieldSuggestion('servings')
                 return s ? (
                   <FieldAISuggestionChip
                     field="servings"
@@ -875,7 +885,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   </div>
                 )}
                 {(() => {
-                  const s = visibleSuggestions.find(x => x.field === 'tags')
+                  const s = getFieldSuggestion('tags')
                   return s ? (
                     <FieldAISuggestionChip
                       field="tags"
@@ -944,7 +954,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   </div>
                 )}
                 {(() => {
-                  const s = visibleSuggestions.find(x => x.field === 'dietaryRestrictions')
+                  const s = getFieldSuggestion('dietaryRestrictions')
                   return s ? (
                     <FieldAISuggestionChip
                       field="dietaryRestrictions"

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isBulkSuggestion } from '../hooks/useAISuggestions'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { FIELD_LABELS, STEP_FIELDS } from '../constants/aiConstants'
 import { AISpinnerIcon } from './AISpinnerIcon'
@@ -44,13 +45,18 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
   onRetry,
   currentStep,
 }) => {
+  const bulkSuggestions = React.useMemo(
+    () => suggestions.filter(isBulkSuggestion),
+    [suggestions]
+  )
+
   const stepFilteredSuggestions = React.useMemo(() => {
-    if (currentStep === undefined) return suggestions
+    if (currentStep === undefined) return bulkSuggestions
     const allowedFields = STEP_FIELDS[currentStep] ?? []
     // No mapping for this step → show all (steps 2, 3 etc. are not restricted)
-    if (allowedFields.length === 0) return suggestions
-    return suggestions.filter(s => allowedFields.includes(s.field))
-  }, [suggestions, currentStep])
+    if (allowedFields.length === 0) return bulkSuggestions
+    return bulkSuggestions.filter(s => allowedFields.includes(s.field))
+  }, [bulkSuggestions, currentStep])
 
   const autoCollapsed = status === 'success' && stepFilteredSuggestions.length === 0
   const [isExpanded, setIsExpanded] = React.useState(!autoCollapsed)

--- a/src/features/recipes/components/AISuggestionPanel.tsx
+++ b/src/features/recipes/components/AISuggestionPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { isBulkSuggestion } from '../hooks/useAISuggestions'
+import { getSuggestionKey, isBulkSuggestion } from '../hooks/useAISuggestions'
 import type { FieldSuggestion, SuggestionStatus } from '../hooks/useAISuggestions'
 import { FIELD_LABELS, STEP_FIELDS } from '../constants/aiConstants'
 import { AISpinnerIcon } from './AISpinnerIcon'
@@ -15,8 +15,8 @@ interface AISuggestionPanelProps {
   suggestions: FieldSuggestion[]
   status: SuggestionStatus
   error: string | null
-  onApply: (field: string, applyFn: (value: string) => void, previousValue: string) => void
-  onDismiss: (field: string) => void
+  onApply: (suggestion: FieldSuggestion, applyFn: (value: string) => void, previousValue: string) => void
+  onDismiss: (suggestion: FieldSuggestion) => void
   /** Maps field names to their corresponding form setter functions */
   fieldSetters: Partial<Record<string, (value: string) => void>>
   /** Current form values keyed by field name */
@@ -139,7 +139,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                 const previousValue = currentValue ?? ''
                 return (
                   <li
-                    key={suggestion.field}
+                    key={getSuggestionKey(suggestion)}
                     className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50/70 p-3 dark:border-gray-700 dark:bg-gray-800/60 sm:flex-row sm:items-center"
                     role="listitem"
                     aria-label={`AI suggestion for ${label}`}
@@ -173,7 +173,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                       {setter && (
                         <button
                           type="button"
-                          onClick={() => onApply(suggestion.field, setter, previousValue)}
+                          onClick={() => onApply(suggestion, setter, previousValue)}
                           className={AI_PRIMARY_ACTION_CLASS}
                           aria-label={`Apply AI suggestion for ${label}`}
                         >
@@ -182,7 +182,7 @@ export const AISuggestionPanel: React.FC<AISuggestionPanelProps> = ({
                       )}
                         <button
                           type="button"
-                          onClick={() => onDismiss(suggestion.field)}
+                          onClick={() => onDismiss(suggestion)}
                           className={AI_SECONDARY_ACTION_CLASS}
                           aria-label={`Dismiss AI suggestion for ${label}`}
                         >

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -372,8 +372,8 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     })
   }, [fetchFieldSuggestion, title, description, tags, dietaryRestrictions, ingredients, instructions])
 
-  const handleApplyFieldSuggestion = useCallback((field: string, value: string) => {
-    const setter = fieldSetters[field]
+  const handleApplyFieldSuggestion = useCallback((suggestion: import('../hooks/useAISuggestions').FieldSuggestion) => {
+    const setter = fieldSetters[suggestion.field]
     const previousValue = {
       recipeName: title,
       description,
@@ -382,9 +382,9 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
       servings,
       tags,
       dietaryRestrictions,
-    }[field] ?? ''
+    }[suggestion.field] ?? ''
     if (setter) {
-      applySuggestion(field, () => setter(value), previousValue)
+      applySuggestion(suggestion, () => setter(suggestion.suggestedValue), previousValue)
     }
   }, [fieldSetters, title, description, prepTime, cookTime, servings, tags, dietaryRestrictions, applySuggestion])
 

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -6,7 +6,7 @@ import { AISpinnerIcon } from './AISpinnerIcon'
 
 import { RecipePreview } from './RecipePreview'
 import { AISuggestionPanel } from './AISuggestionPanel'
-import { useAISuggestions } from '../hooks/useAISuggestions'
+import { isFieldSuggestion, useAISuggestions } from '../hooks/useAISuggestions'
 import { useInstructionRefinement } from '../hooks/useInstructionRefinement'
 import { useAIImageGeneration } from '../hooks/useAIImageGeneration'
 import { FIELD_LABELS } from '../constants/aiConstants'
@@ -411,6 +411,11 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     fetchSuggestions(buildSuggestionRequest())
   }
 
+  const fieldVisibleSuggestions = useMemo(
+    () => visibleSuggestions.filter(isFieldSuggestion),
+    [visibleSuggestions]
+  )
+
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       {/* Header with Step Indicator */}
@@ -555,7 +560,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 onDismissNormalization={onDismissNormalization}
                 onEnhanceField={handleEnhanceField}
                 fieldStatus={fieldStatus}
-                fieldSuggestions={visibleSuggestions}
+                fieldSuggestions={fieldVisibleSuggestions}
                 onApplyFieldSuggestion={handleApplyFieldSuggestion}
                 onDismissFieldSuggestion={dismissSuggestion}
                 onGenerateAIImage={setImagePreview ? handleGenerateAIImage : undefined}

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -75,8 +75,8 @@ interface RecipeFormStepsProps {
   onEnhanceField?: <K extends SuggestibleFieldKey>(field: K, currentValue: SuggestibleFieldValue<K>) => void
   fieldStatus?: Map<string, SuggestionStatus>
   fieldSuggestions?: FieldSuggestion[]
-  onApplyFieldSuggestion?: (field: string, value: string) => void
-  onDismissFieldSuggestion?: (field: string) => void
+  onApplyFieldSuggestion?: (suggestion: FieldSuggestion) => void
+  onDismissFieldSuggestion?: (suggestion: FieldSuggestion) => void
   // AI Image Generation
   onGenerateAIImage?: (recipeName: string, description?: string) => Promise<void>
   generatingAIImage?: boolean
@@ -200,8 +200,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="recipeName"
                   suggestion={s.suggestedValue}
                   currentValue={title}
-                  onApply={() => onApplyFieldSuggestion?.('recipeName', s.suggestedValue)}
-                  onDismiss={() => onDismissFieldSuggestion?.('recipeName')}
+                  onApply={() => onApplyFieldSuggestion?.(s)}
+                  onDismiss={() => onDismissFieldSuggestion?.(s)}
                 />
               ) : null
             })()}
@@ -236,8 +236,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="description"
                   suggestion={s.suggestedValue}
                   currentValue={description}
-                  onApply={() => onApplyFieldSuggestion?.('description', s.suggestedValue)}
-                  onDismiss={() => onDismissFieldSuggestion?.('description')}
+                  onApply={() => onApplyFieldSuggestion?.(s)}
+                  onDismiss={() => onDismissFieldSuggestion?.(s)}
                 />
               ) : null
             })()}
@@ -505,8 +505,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     field="prepTime"
                     suggestion={s.suggestedValue}
                     currentValue={prepTime}
-                    onApply={() => onApplyFieldSuggestion?.('prepTime', s.suggestedValue)}
-                    onDismiss={() => onDismissFieldSuggestion?.('prepTime')}
+                    onApply={() => onApplyFieldSuggestion?.(s)}
+                    onDismiss={() => onDismissFieldSuggestion?.(s)}
                   />
                 ) : null
               })()}
@@ -543,8 +543,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     field="cookTime"
                     suggestion={s.suggestedValue}
                     currentValue={cookTime}
-                    onApply={() => onApplyFieldSuggestion?.('cookTime', s.suggestedValue)}
-                    onDismiss={() => onDismissFieldSuggestion?.('cookTime')}
+                    onApply={() => onApplyFieldSuggestion?.(s)}
+                    onDismiss={() => onDismissFieldSuggestion?.(s)}
                   />
                 ) : null
               })()}
@@ -581,8 +581,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                     field="servings"
                     suggestion={s.suggestedValue}
                     currentValue={servings}
-                    onApply={() => onApplyFieldSuggestion?.('servings', s.suggestedValue)}
-                    onDismiss={() => onDismissFieldSuggestion?.('servings')}
+                    onApply={() => onApplyFieldSuggestion?.(s)}
+                    onDismiss={() => onDismissFieldSuggestion?.(s)}
                   />
                 ) : null
               })()}
@@ -654,8 +654,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="tags"
                   suggestion={s.suggestedValue}
                   currentValue={stringifySuggestionList(tags)}
-                  onApply={() => onApplyFieldSuggestion?.('tags', s.suggestedValue)}
-                  onDismiss={() => onDismissFieldSuggestion?.('tags')}
+                  onApply={() => onApplyFieldSuggestion?.(s)}
+                  onDismiss={() => onDismissFieldSuggestion?.(s)}
                 />
               ) : null
             })()}
@@ -725,8 +725,8 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   field="dietaryRestrictions"
                   suggestion={s.suggestedValue}
                   currentValue={stringifySuggestionList(dietaryRestrictions)}
-                  onApply={() => onApplyFieldSuggestion?.('dietaryRestrictions', s.suggestedValue)}
-                  onDismiss={() => onDismissFieldSuggestion?.('dietaryRestrictions')}
+                  onApply={() => onApplyFieldSuggestion?.(s)}
+                  onDismiss={() => onDismissFieldSuggestion?.(s)}
                 />
               ) : null
             })()}

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -4,6 +4,7 @@ import { UI_STYLES } from '../../../utils/uiStyles'
 import { clampedNumericHandler } from '../../../utils/formUtils'
 import type { Ingredient } from '../../../types/nutrition'
 import type { StepRefinementState, RefinementLoadingState } from '../hooks/useInstructionRefinement'
+import { isFieldSuggestion } from '../hooks/useAISuggestions'
 import { InstructionDiffView } from './InstructionDiffView'
 import { FieldAIEnhanceButton } from './FieldAIEnhanceButton'
 import { FieldAISuggestionChip } from './FieldAISuggestionChip'
@@ -142,7 +143,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
     fieldStatus?.get(field) ?? 'idle'
 
   const getFieldSuggestion = (field: string): FieldSuggestion | undefined =>
-    fieldSuggestions?.find(s => s.field === field)
+    fieldSuggestions?.find(s => s.field === field && isFieldSuggestion(s))
 
   return (
     <div className="space-y-8">

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -122,7 +122,11 @@ describe('AISuggestionPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /apply ai suggestion for description/i }))
-    expect(onApply).toHaveBeenCalledWith('description', setter, expect.any(String))
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'description', suggestedValue: 'A delicious pasta dish' }),
+      setter,
+      expect.any(String)
+    )
   })
 
   it('calls onDismiss with field name when Dismiss is clicked', () => {
@@ -138,7 +142,9 @@ describe('AISuggestionPanel', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /dismiss ai suggestion for description/i }))
-    expect(onDismiss).toHaveBeenCalledWith('description')
+    expect(onDismiss).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'description', suggestedValue: 'A delicious pasta dish' })
+    )
   })
 
   it('shows AI labels that distinguish current and suggested values', () => {
@@ -306,7 +312,11 @@ describe('Before/after comparison', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /apply ai suggestion for description/i }))
-    expect(onApply).toHaveBeenCalledWith('description', setter, 'My current description')
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'description', suggestedValue: 'A delicious pasta dish' }),
+      setter,
+      'My current description'
+    )
   })
 })
 

--- a/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
+++ b/src/features/recipes/components/__tests__/AISuggestionPanel.test.tsx
@@ -222,6 +222,25 @@ describe('AISuggestionPanel', () => {
     expect(screen.queryByRole('button', { name: /apply/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument()
   })
+
+  it('does not render field-scoped suggestions in the panel', () => {
+    render(
+      <AISuggestionPanel
+        suggestions={[
+          { field: 'description', suggestedValue: 'Bulk description', reason: '', source: 'bulk' },
+          { field: 'prepTime', suggestedValue: '12', reason: '', source: 'field' },
+        ]}
+        status="success"
+        error={null}
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        fieldSetters={{ description: vi.fn(), prepTime: vi.fn() }}
+      />
+    )
+
+    expect(screen.getByText('Bulk description')).toBeInTheDocument()
+    expect(screen.queryByText('12')).not.toBeInTheDocument()
+  })
 })
 
 // ─── Before/After comparison (issue #38) ─────────────────────────────────────

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -212,7 +212,9 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /apply/i }))
-    expect(onApply).toHaveBeenCalledWith('recipeName', 'Amazing Pasta')
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'recipeName', suggestedValue: 'Amazing Pasta', source: 'field' })
+    )
   })
 
   it('calls onDismissFieldSuggestion when Dismiss clicked on chip', () => {
@@ -229,7 +231,9 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
       />
     )
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
-    expect(onDismiss).toHaveBeenCalledWith('recipeName')
+    expect(onDismiss).toHaveBeenCalledWith(
+      expect.objectContaining({ field: 'recipeName', suggestedValue: 'Amazing Pasta', source: 'field' })
+    )
   })
 
   it('shows AI enhance buttons for tags and dietary restrictions on step 4', () => {
@@ -267,7 +271,13 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
 
     expect(screen.getByText('gluten-free, dairy-free')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /apply/i }))
-    expect(onApply).toHaveBeenCalledWith('dietaryRestrictions', 'gluten-free, dairy-free')
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'dietaryRestrictions',
+        suggestedValue: 'gluten-free, dairy-free',
+        source: 'field',
+      })
+    )
   })
 
   it('does not render bulk suggestions as inline chips', () => {

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -189,7 +189,7 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
         {...makeProps({
           currentStep: 1,
           onEnhanceField: vi.fn(),
-          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great' }],
+          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great', source: 'field' }],
           onApplyFieldSuggestion: vi.fn(),
           onDismissFieldSuggestion: vi.fn(),
         })}
@@ -205,7 +205,7 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
         {...makeProps({
           currentStep: 1,
           onEnhanceField: vi.fn(),
-          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great' }],
+          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great', source: 'field' }],
           onApplyFieldSuggestion: onApply,
           onDismissFieldSuggestion: vi.fn(),
         })}
@@ -222,7 +222,7 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
         {...makeProps({
           currentStep: 1,
           onEnhanceField: vi.fn(),
-          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great' }],
+          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Amazing Pasta', reason: 'Sounds great', source: 'field' }],
           onApplyFieldSuggestion: vi.fn(),
           onDismissFieldSuggestion: onDismiss,
         })}
@@ -257,7 +257,7 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
           currentStep: 4,
           onEnhanceField: vi.fn(),
           fieldSuggestions: [
-            { field: 'dietaryRestrictions', suggestedValue: 'gluten-free, dairy-free', reason: 'Matches ingredients' },
+            { field: 'dietaryRestrictions', suggestedValue: 'gluten-free, dairy-free', reason: 'Matches ingredients', source: 'field' },
           ],
           onApplyFieldSuggestion: onApply,
           onDismissFieldSuggestion: vi.fn(),
@@ -268,6 +268,22 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
     expect(screen.getByText('gluten-free, dairy-free')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /apply/i }))
     expect(onApply).toHaveBeenCalledWith('dietaryRestrictions', 'gluten-free, dairy-free')
+  })
+
+  it('does not render bulk suggestions as inline chips', () => {
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          currentStep: 1,
+          onEnhanceField: vi.fn(),
+          fieldSuggestions: [{ field: 'recipeName', suggestedValue: 'Bulk title', reason: 'Bulk only' }],
+          onApplyFieldSuggestion: vi.fn(),
+          onDismissFieldSuggestion: vi.fn(),
+        })}
+      />
+    )
+
+    expect(screen.queryByText('Bulk title')).not.toBeInTheDocument()
   })
 })
 

--- a/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
@@ -98,7 +98,7 @@ describe('useAISuggestions', () => {
 
     const setter = vi.fn()
     act(() => {
-      result.current.applySuggestion('description', setter, '')
+      result.current.applySuggestion(result.current.suggestions[0], setter, '')
     })
 
     expect(setter).toHaveBeenCalledWith('A tasty dish')
@@ -123,12 +123,12 @@ describe('useAISuggestions', () => {
     })
 
     act(() => {
-      result.current.dismissSuggestion('description')
+      result.current.dismissSuggestion(result.current.suggestions[0])
     })
 
     expect(result.current.visibleSuggestions).toHaveLength(1)
     expect(result.current.visibleSuggestions[0].field).toBe('prepTime')
-    expect(result.current.dismissedFields.has('description')).toBe(true)
+    expect(result.current.dismissedFields.has('bulk:description')).toBe(true)
   })
 
   it('dismissing one suggestion does not affect other suggestions', async () => {
@@ -149,7 +149,7 @@ describe('useAISuggestions', () => {
     })
 
     act(() => {
-      result.current.dismissSuggestion('prepTime')
+      result.current.dismissSuggestion(result.current.suggestions[0])
     })
 
     const visible = result.current.visibleSuggestions
@@ -179,13 +179,13 @@ describe('useAISuggestions', () => {
         // Apply suggestion
     const setter = vi.fn()
     act(() => {
-      result.current.applySuggestion('description', setter, '')
+      result.current.applySuggestion(result.current.suggestions[0], setter, '')
     })
     expect(events).toContain('ai_suggestion_applied')
 
     // Dismiss suggestion (should be no-op since it's already applied, but event should still fire)
     act(() => {
-      result.current.dismissSuggestion('description')
+      result.current.dismissSuggestion(result.current.suggestions[0])
     })
     expect(events).toContain('ai_suggestion_dismissed')
 
@@ -392,6 +392,98 @@ describe('useAISuggestions', () => {
           expect.objectContaining({ suggestedValue: 'Field description', source: 'field' }),
         ])
       )
+    })
+
+    it('applying a field suggestion uses that suggestion instead of the bulk suggestion for the same field', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Bulk description', reason: '' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Pasta' })
+      })
+
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Field description', reason: '' }],
+        },
+      } as any)
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      const setter = vi.fn()
+      const fieldSuggestion = result.current.suggestions.find(
+        suggestion => suggestion.field === 'description' && suggestion.source === 'field'
+      )
+
+      expect(fieldSuggestion).toBeDefined()
+
+      act(() => {
+        result.current.applySuggestion(fieldSuggestion!, setter, '')
+      })
+
+      expect(setter).toHaveBeenCalledWith('Field description')
+      expect(
+        result.current.visibleSuggestions.find(
+          suggestion => suggestion.field === 'description' && suggestion.source === 'bulk'
+        )
+      ).toBeDefined()
+      expect(
+        result.current.visibleSuggestions.find(
+          suggestion => suggestion.field === 'description' && suggestion.source === 'field'
+        )
+      ).toBeUndefined()
+    })
+
+    it('dismissing a field suggestion does not hide the bulk suggestion for the same field', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Bulk description', reason: '' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Pasta' })
+      })
+
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Field description', reason: '' }],
+        },
+      } as any)
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      const fieldSuggestion = result.current.suggestions.find(
+        suggestion => suggestion.field === 'description' && suggestion.source === 'field'
+      )
+
+      expect(fieldSuggestion).toBeDefined()
+
+      act(() => {
+        result.current.dismissSuggestion(fieldSuggestion!)
+      })
+
+      expect(
+        result.current.visibleSuggestions.find(
+          suggestion => suggestion.field === 'description' && suggestion.source === 'bulk'
+        )
+      ).toBeDefined()
+      expect(
+        result.current.visibleSuggestions.find(
+          suggestion => suggestion.field === 'description' && suggestion.source === 'field'
+        )
+      ).toBeUndefined()
     })
   })
 

--- a/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
+++ b/src/features/recipes/hooks/__tests__/useAISuggestions.test.ts
@@ -60,6 +60,7 @@ describe('useAISuggestions', () => {
 
     expect(result.current.suggestions).toHaveLength(1)
     expect(result.current.suggestions[0].field).toBe('description')
+    expect(result.current.suggestions[0].source).toBe('bulk')
     expect(result.current.visibleSuggestions).toHaveLength(1)
   })
 
@@ -234,6 +235,7 @@ describe('useAISuggestions', () => {
       expect(result.current.suggestions).toHaveLength(1)
       expect(result.current.suggestions[0].field).toBe('description')
       expect(result.current.suggestions[0].suggestedValue).toBe('A delicious meal')
+      expect(result.current.suggestions[0].source).toBe('field')
     })
 
     it('should set fieldStatus[field] to success after fetch', async () => {
@@ -264,7 +266,7 @@ describe('useAISuggestions', () => {
       expect(result.current.fieldStatus.get('cookTime')).toBe('error')
     })
 
-    it('should not affect fieldStatus or suggestions for other fields', async () => {
+    it('should not affect fieldStatus or bulk suggestions for other fields', async () => {
       // Pre-populate suggestions for another field via fetchSuggestions
       mockPostWithAuth.mockResolvedValueOnce({
         data: {
@@ -289,10 +291,17 @@ describe('useAISuggestions', () => {
         await result.current.fetchFieldSuggestion('description', '')
       })
 
-      // prepTime suggestion should still be present
+      // prepTime bulk suggestion should still be present
       const prepTimeSuggestion = result.current.suggestions.find(s => s.field === 'prepTime')
       expect(prepTimeSuggestion).toBeDefined()
       expect(prepTimeSuggestion?.suggestedValue).toBe('10 min')
+      expect(prepTimeSuggestion?.source).toBe('bulk')
+
+      const descriptionSuggestion = result.current.suggestions.find(
+        s => s.field === 'description' && s.source === 'field'
+      )
+      expect(descriptionSuggestion).toBeDefined()
+      expect(descriptionSuggestion?.suggestedValue).toBe('Tasty')
 
       // fieldStatus for description should be success, prepTime unaffected
       expect(result.current.fieldStatus.get('description')).toBe('success')
@@ -350,6 +359,39 @@ describe('useAISuggestions', () => {
       expect(result.current.suggestions.map(s => s.field)).toContain('prepTime')
       expect(result.current.suggestions.map(s => s.field)).toContain('cookTime')
       expect(result.current.suggestions.map(s => s.field)).toContain('description')
+    })
+
+    it('keeps bulk and field suggestions for the same field side by side', async () => {
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Bulk description', reason: '' }],
+        },
+      } as any)
+
+      const { result } = renderHook(() => useAISuggestions())
+
+      await act(async () => {
+        await result.current.fetchSuggestions({ recipeName: 'Pasta' })
+      })
+
+      mockPostWithAuth.mockResolvedValueOnce({
+        data: {
+          suggestions: [{ field: 'description', suggestedValue: 'Field description', reason: '' }],
+        },
+      } as any)
+
+      await act(async () => {
+        await result.current.fetchFieldSuggestion('description', '')
+      })
+
+      const descriptionSuggestions = result.current.suggestions.filter(s => s.field === 'description')
+      expect(descriptionSuggestions).toHaveLength(2)
+      expect(descriptionSuggestions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ suggestedValue: 'Bulk description', source: 'bulk' }),
+          expect.objectContaining({ suggestedValue: 'Field description', source: 'field' }),
+        ])
+      )
     })
   })
 

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -7,11 +7,28 @@ import type { AuditEntry, UndoResult } from './useAIAuditTrail'
 export type { AuditEntry, UndoResult }
 
 /** A single AI-generated suggestion for one recipe field. */
+export type SuggestionSource = 'bulk' | 'field'
+
 export interface FieldSuggestion {
   field: string
   suggestedValue: string
   reason: string
+  source?: SuggestionSource
 }
+
+export const getSuggestionSource = (suggestion: Pick<FieldSuggestion, 'source'>): SuggestionSource =>
+  suggestion.source ?? 'bulk'
+
+export const isBulkSuggestion = (suggestion: Pick<FieldSuggestion, 'source'>): boolean =>
+  getSuggestionSource(suggestion) === 'bulk'
+
+export const isFieldSuggestion = (suggestion: Pick<FieldSuggestion, 'source'>): boolean =>
+  getSuggestionSource(suggestion) === 'field'
+
+const withSuggestionSource = (
+  suggestions: FieldSuggestion[],
+  source: SuggestionSource
+): FieldSuggestion[] => suggestions.map(suggestion => ({ ...suggestion, source }))
 
 /** Request payload for the suggest-fields endpoint. */
 export interface FieldSuggestionRequest {
@@ -94,7 +111,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       const url = buildApiUrl(apiBase, '/api/recipes/suggest-fields')
       const res = await postWithAuth(url, request)
       const data = res.data as { suggestions: FieldSuggestion[] }
-      const fetched = data?.suggestions ?? []
+      const fetched = withSuggestionSource(data?.suggestions ?? [], 'bulk')
       setSuggestions(fetched)
       setDismissedFields(new Set())
       setStatus('success')
@@ -140,11 +157,11 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       const url = buildApiUrl(apiBase, '/api/recipes/suggest-fields')
       const res = await postWithAuth(url, request)
       const data = res.data as { suggestions: FieldSuggestion[] }
-      const fetched = data?.suggestions ?? []
+      const fetched = withSuggestionSource(data?.suggestions ?? [], 'field')
       const fieldSuggestions = fetched.filter(s => s.field === field)
 
       setSuggestions(prev => {
-        const withoutField = prev.filter(s => s.field !== field)
+        const withoutField = prev.filter(s => !(s.field === field && isFieldSuggestion(s)))
         return [...withoutField, ...fieldSuggestions]
       })
       setDismissedFields(prev => {

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -25,6 +25,9 @@ export const isBulkSuggestion = (suggestion: Pick<FieldSuggestion, 'source'>): b
 export const isFieldSuggestion = (suggestion: Pick<FieldSuggestion, 'source'>): boolean =>
   getSuggestionSource(suggestion) === 'field'
 
+export const getSuggestionKey = (suggestion: Pick<FieldSuggestion, 'field' | 'source'>): string =>
+  `${getSuggestionSource(suggestion)}:${suggestion.field}`
+
 const withSuggestionSource = (
   suggestions: FieldSuggestion[],
   source: SuggestionSource
@@ -64,8 +67,8 @@ interface UseAISuggestionsReturn {
     context?: Partial<FieldSuggestionRequest>
   ) => Promise<void>
   fieldStatus: Map<string, SuggestionStatus>
-  applySuggestion: (field: string, applyFn: (value: string) => void, previousValue: unknown) => void
-  dismissSuggestion: (field: string) => void
+  applySuggestion: (suggestion: FieldSuggestion, applyFn: (value: string) => void, previousValue: unknown) => void
+  dismissSuggestion: (suggestion: FieldSuggestion) => void
   visibleSuggestions: FieldSuggestion[]
   // Audit trail
   auditLog: AuditEntry[]
@@ -166,7 +169,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       })
       setDismissedFields(prev => {
         const next = new Set(prev)
-        next.delete(field)
+        next.delete(getSuggestionKey({ field, source: 'field' }))
         return next
       })
       setFieldStatus(prev => new Map(prev).set(field, 'success'))
@@ -182,31 +185,32 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     }
   }, [recordSuggestion])
 
-  const applySuggestion = useCallback((field: string, applyFn: (value: string) => void, previousValue: unknown) => {
-    const suggestion = suggestions.find(s => s.field === field)
+  const applySuggestion = useCallback((suggestionToApply: FieldSuggestion, applyFn: (value: string) => void, previousValue: unknown) => {
+    const suggestion = suggestions.find(s => getSuggestionKey(s) === getSuggestionKey(suggestionToApply))
     if (!suggestion) return
+    const suggestionKey = getSuggestionKey(suggestion)
 
     applyFn(suggestion.suggestedValue)
-    setDismissedFields(prev => new Set([...prev, field]))
+    setDismissedFields(prev => new Set([...prev, suggestionKey]))
 
-    recordAccepted(field, previousValue, suggestion.suggestedValue)
+    recordAccepted(suggestion.field, previousValue, suggestion.suggestedValue)
 
-    const event = { type: 'ai_suggestion_applied', field }
+    const event = { type: 'ai_suggestion_applied', field: suggestion.field, source: getSuggestionSource(suggestion) }
     console.log('[AI Suggestions]', event)
     window.dispatchEvent(new CustomEvent('ai:suggestions', { detail: event }))
   }, [suggestions, recordAccepted])
 
-  const dismissSuggestion = useCallback((field: string) => {
-    setDismissedFields(prev => new Set([...prev, field]))
+  const dismissSuggestion = useCallback((suggestion: FieldSuggestion) => {
+    setDismissedFields(prev => new Set([...prev, getSuggestionKey(suggestion)]))
 
-    recordRejected(field)
+    recordRejected(suggestion.field)
 
-    const event = { type: 'ai_suggestion_dismissed', field }
+    const event = { type: 'ai_suggestion_dismissed', field: suggestion.field, source: getSuggestionSource(suggestion) }
     console.log('[AI Suggestions]', event)
     window.dispatchEvent(new CustomEvent('ai:suggestions', { detail: event }))
   }, [recordRejected])
 
-  const visibleSuggestions = suggestions.filter(s => !dismissedFields.has(s.field))
+  const visibleSuggestions = suggestions.filter(s => !dismissedFields.has(getSuggestionKey(s)))
 
   return {
     suggestions,


### PR DESCRIPTION
## Problem
Field-level AI suggestions were using the same visible suggestion list as bulk AI assist results, so the same suggestion could appear both inline and in the top suggestions panel.

## Changes
- tag suggestions as bulk or field when they are fetched
- keep bulk and field suggestions side by side in the hook so a field enhancement does not overwrite the bulk suggestion for that field
- render only bulk suggestions in AISuggestionPanel
- render only field suggestions in inline chips for both simple and step-based recipe forms
- add regression coverage for the hook and both UI surfaces

Related issue: theandiman/recipe-management#44
