### PR TITLE
fix: polish field ai suggestion chip

### DIFF
--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -473,6 +473,33 @@ describe('AI Enhancement', () => {
     expect(screen.getByText('dairy-free')).toBeInTheDocument()
   })
 
+  it('shows the AI reason on inline field suggestions in quick entry mode', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          {
+            field: 'recipeName',
+            suggestedValue: 'Amazing Pasta',
+            reason: 'Sounds more specific',
+          },
+        ],
+      },
+    } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.change(screen.getByPlaceholderText(/Grandma's Chocolate Chip Cookies/i), {
+      target: { value: 'Pasta' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Enhance with AI/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Amazing Pasta')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Sounds more specific')).toBeInTheDocument()
+  })
+
   it('saves accepted AI nutrition estimates with the recipe', async () => {
     const { postWithAuth } = await import('../../utils/authApi')
     vi.mocked(postWithAuth).mockResolvedValueOnce({

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -462,6 +462,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 <FieldAISuggestionChip
                   field="recipeName"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={form.title}
                   onApply={() => handleApplyFieldSuggestion(s)}
                   onDismiss={() => dismissSuggestion(s)}
@@ -497,6 +498,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 <FieldAISuggestionChip
                   field="description"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={form.description}
                   onApply={() => handleApplyFieldSuggestion(s)}
                   onDismiss={() => dismissSuggestion(s)}
@@ -676,6 +678,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     <FieldAISuggestionChip
                       field="prepTime"
                       suggestion={s.suggestedValue}
+                      reason={s.reason}
                       currentValue={form.prepTime}
                       onApply={() => handleApplyFieldSuggestion(s)}
                       onDismiss={() => dismissSuggestion(s)}
@@ -715,6 +718,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     <FieldAISuggestionChip
                       field="cookTime"
                       suggestion={s.suggestedValue}
+                      reason={s.reason}
                       currentValue={form.cookTime}
                       onApply={() => handleApplyFieldSuggestion(s)}
                       onDismiss={() => dismissSuggestion(s)}
@@ -766,6 +770,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   <FieldAISuggestionChip
                     field="servings"
                     suggestion={s.suggestedValue}
+                    reason={s.reason}
                     currentValue={form.servings}
                     onApply={() => handleApplyFieldSuggestion(s)}
                     onDismiss={() => dismissSuggestion(s)}
@@ -890,6 +895,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     <FieldAISuggestionChip
                       field="tags"
                       suggestion={s.suggestedValue}
+                      reason={s.reason}
                       currentValue={stringifySuggestionList(form.tags)}
                       onApply={() => handleApplyFieldSuggestion(s)}
                       onDismiss={() => dismissSuggestion(s)}
@@ -959,6 +965,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     <FieldAISuggestionChip
                       field="dietaryRestrictions"
                       suggestion={s.suggestedValue}
+                      reason={s.reason}
                       currentValue={stringifySuggestionList(form.dietaryRestrictions)}
                       onApply={() => handleApplyFieldSuggestion(s)}
                       onDismiss={() => dismissSuggestion(s)}

--- a/src/features/recipes/components/FieldAISuggestionChip.tsx
+++ b/src/features/recipes/components/FieldAISuggestionChip.tsx
@@ -9,6 +9,7 @@ import {
 export interface FieldAISuggestionChipProps {
   field: string
   suggestion: string
+  reason?: string
   currentValue: string
   onApply: () => void
   onDismiss: () => void
@@ -16,12 +17,13 @@ export interface FieldAISuggestionChipProps {
 
 export const FieldAISuggestionChip: React.FC<FieldAISuggestionChipProps> = ({
   suggestion,
+  reason,
   currentValue,
   onApply,
   onDismiss,
 }) => {
   return (
-    <div className={`mt-2 px-3 py-3 text-sm flex items-start gap-3 ${AI_MUTED_PANEL_CLASS}`}>
+    <div className={`mt-2 px-3 py-3 text-sm flex items-start gap-3 animate-field-ai-chip-enter ${AI_MUTED_PANEL_CLASS}`}>
       <div className="flex-1 min-w-0">
         <p className={AI_EYEBROW_CLASS}>AI suggestion</p>
         {currentValue && (
@@ -31,6 +33,9 @@ export const FieldAISuggestionChip: React.FC<FieldAISuggestionChipProps> = ({
           </p>
         )}
         <p className="leading-5 text-gray-800 dark:text-gray-100">{suggestion}</p>
+        {reason && (
+          <p className="mt-1 text-xs italic text-gray-500 dark:text-gray-400">{reason}</p>
+        )}
       </div>
       <div className="flex items-center gap-1.5 shrink-0">
         <button

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -199,6 +199,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 <FieldAISuggestionChip
                   field="recipeName"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={title}
                   onApply={() => onApplyFieldSuggestion?.(s)}
                   onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -235,6 +236,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 <FieldAISuggestionChip
                   field="description"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={description}
                   onApply={() => onApplyFieldSuggestion?.(s)}
                   onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -503,6 +505,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   <FieldAISuggestionChip
                     field="prepTime"
                     suggestion={s.suggestedValue}
+                    reason={s.reason}
                     currentValue={prepTime}
                     onApply={() => onApplyFieldSuggestion?.(s)}
                     onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -541,6 +544,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   <FieldAISuggestionChip
                     field="cookTime"
                     suggestion={s.suggestedValue}
+                    reason={s.reason}
                     currentValue={cookTime}
                     onApply={() => onApplyFieldSuggestion?.(s)}
                     onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -579,6 +583,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                   <FieldAISuggestionChip
                     field="servings"
                     suggestion={s.suggestedValue}
+                    reason={s.reason}
                     currentValue={servings}
                     onApply={() => onApplyFieldSuggestion?.(s)}
                     onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -652,6 +657,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 <FieldAISuggestionChip
                   field="tags"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={stringifySuggestionList(tags)}
                   onApply={() => onApplyFieldSuggestion?.(s)}
                   onDismiss={() => onDismissFieldSuggestion?.(s)}
@@ -723,6 +729,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 <FieldAISuggestionChip
                   field="dietaryRestrictions"
                   suggestion={s.suggestedValue}
+                  reason={s.reason}
                   currentValue={stringifySuggestionList(dietaryRestrictions)}
                   onApply={() => onApplyFieldSuggestion?.(s)}
                   onDismiss={() => onDismissFieldSuggestion?.(s)}

--- a/src/features/recipes/components/__tests__/FieldAISuggestionChip.test.tsx
+++ b/src/features/recipes/components/__tests__/FieldAISuggestionChip.test.tsx
@@ -30,6 +30,24 @@ describe('FieldAISuggestionChip', () => {
     expect(screen.getByText('AI suggestion')).toBeInTheDocument()
   })
 
+  it('renders the optional reason below the suggestion', () => {
+    render(
+      <FieldAISuggestionChip
+        field="recipeName"
+        suggestion="A delicious pasta dish"
+        reason="More descriptive title"
+        currentValue=""
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    const reason = screen.getByText('More descriptive title')
+    expect(reason).toBeInTheDocument()
+    expect(reason.tagName).toBe('P')
+    expect(reason).toHaveClass('italic')
+  })
+
   it('shows Apply and Dismiss buttons', () => {
     render(
       <FieldAISuggestionChip
@@ -101,5 +119,25 @@ describe('FieldAISuggestionChip', () => {
     )
     expect(container.querySelector('s')).not.toBeInTheDocument()
     expect(screen.getByText('New pasta dish')).toBeInTheDocument()
+  })
+
+  it('keeps controls accessible while the entrance animation class is applied', () => {
+    const { container } = render(
+      <FieldAISuggestionChip
+        field="recipeName"
+        suggestion="New pasta dish"
+        reason="Clearer wording"
+        currentValue=""
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    )
+
+    expect(container.firstChild).toHaveAttribute(
+      'class',
+      expect.stringContaining('animate-field-ai-chip-enter')
+    )
+    expect(screen.getByRole('button', { name: /apply/i })).toBeVisible()
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeVisible()
   })
 })

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -201,6 +201,7 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
       />
     )
     expect(screen.getByText('Amazing Pasta')).toBeInTheDocument()
+    expect(screen.getByText('Sounds great')).toBeInTheDocument()
   })
 
   it('calls onApplyFieldSuggestion when Apply clicked on chip', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -72,6 +72,12 @@
   }
 
   .animate-field-ai-chip-enter {
-    animation: field-ai-chip-enter 180ms ease-out;
+    animation: none;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .animate-field-ai-chip-enter {
+      animation: field-ai-chip-enter 180ms ease-out;
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -58,3 +58,20 @@
     @apply text-gray-500;
   }
 }
+
+@layer utilities {
+  @keyframes field-ai-chip-enter {
+    from {
+      opacity: 0;
+      transform: translateY(-0.25rem);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-field-ai-chip-enter {
+    animation: field-ai-chip-enter 180ms ease-out;
+  }
+}


### PR DESCRIPTION
## Problem
Field-level AI suggestion chips did not show the AI's reason and appeared abruptly, which made inline suggestions feel less trustworthy than the bulk suggestion panel.

## Changes
- add an optional `reason` prop to `FieldAISuggestionChip` and render it as muted italic helper text
- pass field suggestion reasons through every inline chip entry point in `RecipeFormSteps`
- add a subtle motion-safe entrance animation for the chip
- extend tests to cover reason rendering and button accessibility while the animation class is present

Related meta issue: theandiman/recipe-management#43.
