### PR TITLE
fix: add AI workflow recovery parity

### DIFF
--- a/src/features/recipes/CreateRecipe.tsx
+++ b/src/features/recipes/CreateRecipe.tsx
@@ -16,6 +16,8 @@ const FIELD_LABELS: Record<string, string> = {
   prepTime: 'Prep Time',
   cookTime: 'Cook Time',
   servings: 'Servings',
+  tags: 'Tags',
+  dietaryRestrictions: 'Dietary Restrictions',
 }
 
 export const CreateRecipe: React.FC = () => {

--- a/src/features/recipes/SimpleCreateRecipe.test.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.test.tsx
@@ -648,4 +648,76 @@ describe('AI Undo Affordance', () => {
       expect(screen.queryByRole('button', { name: /Undo: Description/i })).not.toBeInTheDocument()
     })
   })
+
+  it('reverts applied tag suggestions through undo in quick entry', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth).mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'tags', suggestedValue: 'quick, vegetarian', reason: 'Helpful categorization' },
+        ],
+      },
+    } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    renderWithRouter(<SimpleCreateRecipe />)
+    fireEvent.click(screen.getByRole('button', { name: /Tags & Dietary/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Apply AI suggestion for Tags/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply AI suggestion for Tags/i }))
+
+    expect(screen.getByText('quick')).toBeInTheDocument()
+    expect(screen.getByText('vegetarian')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Undo: Tags/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('quick')).not.toBeInTheDocument()
+      expect(screen.queryByText('vegetarian')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('AI error recovery', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    setDefaultAuthMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows an inline retry state when a field-level AI request fails', async () => {
+    const { postWithAuth } = await import('../../utils/authApi')
+    vi.mocked(postWithAuth)
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({
+        data: {
+          suggestions: [
+            { field: 'recipeName', suggestedValue: 'Weeknight Pasta', reason: 'More descriptive' },
+          ],
+        },
+      } as Awaited<ReturnType<typeof postWithAuth>>)
+
+    const { container } = renderWithRouter(<SimpleCreateRecipe />)
+    const aiButton = container.querySelector('button[data-field="recipeName"]')
+
+    expect(aiButton).not.toBeNull()
+    fireEvent.click(aiButton!)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not enhance Recipe Name\./i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Retry AI for Recipe Name/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Weeknight Pasta')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -1067,6 +1067,7 @@ export const SimpleCreateRecipe: React.FC = () => {
   const isEditMode = Boolean(id)
   const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [loadedRecipeId, setLoadedRecipeId] = useState<string | null>(null)
   const [initialState, setInitialState] = useState<RecipeFormInitialState>()
   const [recipeOverrides, setRecipeOverrides] = useState<Partial<Recipe>>({})
 
@@ -1088,6 +1089,7 @@ export const SimpleCreateRecipe: React.FC = () => {
 
         if (!isMounted) return
 
+        setLoadedRecipeId(id)
         setInitialState(getInitialFormState(recipe))
         setRecipeOverrides({
           nutritionalInfo: recipe.nutritionalInfo,
@@ -1100,6 +1102,7 @@ export const SimpleCreateRecipe: React.FC = () => {
         console.error('Failed to fetch recipe:', err)
         const errorMessage = err instanceof Error ? err.message : 'Failed to load recipe'
         const apiError = err as { response?: { data?: { message?: string } } }
+        setLoadedRecipeId(null)
         setLoadError(apiError.response?.data?.message || errorMessage)
       } finally {
         if (isMounted) {
@@ -1115,7 +1118,7 @@ export const SimpleCreateRecipe: React.FC = () => {
     }
   }, [currentUser?.uid, id, isAuthLoading, isEditMode, navigate])
 
-  if (isEditMode && (loading || (!initialState && !loadError))) {
+  if (isEditMode && (loading || (loadedRecipeId !== id && !loadError))) {
     return (
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center justify-center py-12">
@@ -1150,8 +1153,8 @@ export const SimpleCreateRecipe: React.FC = () => {
       key={id ?? 'create'}
       isEditMode={isEditMode}
       recipeId={id}
-      initialState={isEditMode ? initialState : undefined}
-      recipeOverrides={isEditMode ? recipeOverrides : {}}
+      initialState={isEditMode && loadedRecipeId === id ? initialState : undefined}
+      recipeOverrides={isEditMode && loadedRecipeId === id ? recipeOverrides : {}}
     />
   )
 }

--- a/src/features/recipes/SimpleCreateRecipe.tsx
+++ b/src/features/recipes/SimpleCreateRecipe.tsx
@@ -92,10 +92,15 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
   const form = useRecipeForm(initialState)
   const { validateForm, buildRecipeObject } = useRecipeValidation()
   const sections = useSimpleCreateSections()
-
-  useEffect(() => {
-    setActiveRecipeOverrides(recipeOverrides)
-  }, [recipeOverrides])
+  const {
+    setTitle,
+    setDescription,
+    setPrepTime,
+    setCookTime,
+    setServings,
+    setTags,
+    setDietaryRestrictions,
+  } = form
 
   const { handleSubmit } = useRecipeSave({
     recipeId,
@@ -131,6 +136,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     fetchSuggestions,
     fetchFieldSuggestion,
     fieldStatus,
+    fieldErrors: fieldSuggestionErrors,
     applySuggestion,
     dismissSuggestion,
     canUndo,
@@ -161,21 +167,21 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
   })
 
   const fieldSetters: Partial<Record<string, (value: string) => void>> = useMemo(() => ({
-    recipeName: form.setTitle,
-    description: form.setDescription,
-    prepTime: form.setPrepTime,
-    cookTime: form.setCookTime,
-    servings: form.setServings,
-    tags: (value: string) => form.setTags(parseSuggestedList(value)),
-    dietaryRestrictions: (value: string) => form.setDietaryRestrictions(parseSuggestedList(value)),
+    recipeName: setTitle,
+    description: setDescription,
+    prepTime: setPrepTime,
+    cookTime: setCookTime,
+    servings: setServings,
+    tags: (value: string) => setTags(parseSuggestedList(value)),
+    dietaryRestrictions: (value: string) => setDietaryRestrictions(parseSuggestedList(value)),
   }), [
-    form.setTitle,
-    form.setDescription,
-    form.setPrepTime,
-    form.setCookTime,
-    form.setServings,
-    form.setTags,
-    form.setDietaryRestrictions,
+    setTitle,
+    setDescription,
+    setPrepTime,
+    setCookTime,
+    setServings,
+    setTags,
+    setDietaryRestrictions,
   ])
 
   const currentValues: Partial<Record<string, string>> = useMemo(() => ({
@@ -256,6 +262,39 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
     (field: string) => fieldVisibleSuggestions.find(suggestion => suggestion.field === field),
     [fieldVisibleSuggestions]
   )
+
+  const getFieldSuggestionError = useCallback(
+    (field: string) => fieldSuggestionErrors.get(field) ?? null,
+    [fieldSuggestionErrors]
+  )
+
+  const renderFieldAIFeedback = useCallback(<K extends SuggestibleFieldKey,>(
+    field: K,
+    currentValue: string,
+    fieldValue: SuggestibleFieldValue<K>
+  ) => {
+    const suggestion = getFieldSuggestion(field)
+    const error = getFieldSuggestionError(field)
+
+    if (!suggestion && !error) return null
+
+    return (
+      <FieldAISuggestionChip
+        field={field}
+        suggestion={suggestion?.suggestedValue ?? ''}
+        reason={suggestion?.reason}
+        currentValue={currentValue}
+        error={error}
+        onApply={() => {
+          if (suggestion) handleApplyFieldSuggestion(suggestion)
+        }}
+        onDismiss={() => {
+          if (suggestion) dismissSuggestion(suggestion)
+        }}
+        onRetry={() => handleEnhanceField(field, fieldValue)}
+      />
+    )
+  }, [dismissSuggestion, getFieldSuggestion, getFieldSuggestionError, handleApplyFieldSuggestion, handleEnhanceField])
 
   const lastUndoableAIField = useMemo<string | null>(() => {
     const latestEntry = auditLog[auditLog.length - 1]
@@ -456,19 +495,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 {form.fieldErrors.title}
               </p>
             )}
-            {(() => {
-              const s = getFieldSuggestion('recipeName')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="recipeName"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={form.title}
-                  onApply={() => handleApplyFieldSuggestion(s)}
-                  onDismiss={() => dismissSuggestion(s)}
-                />
-              ) : null
-            })()}
+{renderFieldAIFeedback('recipeName', form.title, form.title)}
           </div>
 
           {/* Description */}
@@ -492,19 +519,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
               placeholder="Brief description of your recipe..."
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
             />
-            {(() => {
-              const s = getFieldSuggestion('description')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="description"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={form.description}
-                  onApply={() => handleApplyFieldSuggestion(s)}
-                  onDismiss={() => dismissSuggestion(s)}
-                />
-              ) : null
-            })()}
+{renderFieldAIFeedback('description', form.description, form.description)}
           </div>
         </div>
 
@@ -672,19 +687,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   placeholder="15"
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
-                {(() => {
-                  const s = getFieldSuggestion('prepTime')
-                  return s ? (
-                    <FieldAISuggestionChip
-                      field="prepTime"
-                      suggestion={s.suggestedValue}
-                      reason={s.reason}
-                      currentValue={form.prepTime}
-                      onApply={() => handleApplyFieldSuggestion(s)}
-                      onDismiss={() => dismissSuggestion(s)}
-                    />
-                  ) : null
-                })()}
+{renderFieldAIFeedback('prepTime', form.prepTime, form.prepTime)}
               </div>
               <div>
                 <div className="flex items-center gap-1.5 mb-2">
@@ -712,19 +715,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                   placeholder="30"
                   className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
                 />
-                {(() => {
-                  const s = getFieldSuggestion('cookTime')
-                  return s ? (
-                    <FieldAISuggestionChip
-                      field="cookTime"
-                      suggestion={s.suggestedValue}
-                      reason={s.reason}
-                      currentValue={form.cookTime}
-                      onApply={() => handleApplyFieldSuggestion(s)}
-                      onDismiss={() => dismissSuggestion(s)}
-                    />
-                  ) : null
-                })()}
+{renderFieldAIFeedback('cookTime', form.cookTime, form.cookTime)}
               </div>
             </div>
           </CollapsibleSection>
@@ -764,19 +755,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                 placeholder="4"
                 className="w-full sm:w-40 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
               />
-              {(() => {
-                const s = getFieldSuggestion('servings')
-                return s ? (
-                  <FieldAISuggestionChip
-                    field="servings"
-                    suggestion={s.suggestedValue}
-                    reason={s.reason}
-                    currentValue={form.servings}
-                    onApply={() => handleApplyFieldSuggestion(s)}
-                    onDismiss={() => dismissSuggestion(s)}
-                  />
-                ) : null
-              })()}
+{renderFieldAIFeedback('servings', form.servings, form.servings)}
             </div>
           </CollapsibleSection>
 
@@ -889,19 +868,7 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     ))}
                   </div>
                 )}
-                {(() => {
-                  const s = getFieldSuggestion('tags')
-                  return s ? (
-                    <FieldAISuggestionChip
-                      field="tags"
-                      suggestion={s.suggestedValue}
-                      reason={s.reason}
-                      currentValue={stringifySuggestionList(form.tags)}
-                      onApply={() => handleApplyFieldSuggestion(s)}
-                      onDismiss={() => dismissSuggestion(s)}
-                    />
-                  ) : null
-                })()}
+{renderFieldAIFeedback('tags', stringifySuggestionList(form.tags), form.tags)}
               </div>
 
               {/* Dietary restrictions */}
@@ -959,19 +926,11 @@ const QuickEntryRecipeForm: React.FC<QuickEntryRecipeFormProps> = ({
                     ))}
                   </div>
                 )}
-                {(() => {
-                  const s = getFieldSuggestion('dietaryRestrictions')
-                  return s ? (
-                    <FieldAISuggestionChip
-                      field="dietaryRestrictions"
-                      suggestion={s.suggestedValue}
-                      reason={s.reason}
-                      currentValue={stringifySuggestionList(form.dietaryRestrictions)}
-                      onApply={() => handleApplyFieldSuggestion(s)}
-                      onDismiss={() => dismissSuggestion(s)}
-                    />
-                  ) : null
-                })()}
+{renderFieldAIFeedback(
+  'dietaryRestrictions',
+  stringifySuggestionList(form.dietaryRestrictions),
+  form.dietaryRestrictions
+)}
               </div>
             </div>
           </CollapsibleSection>
@@ -1106,21 +1065,13 @@ export const SimpleCreateRecipe: React.FC = () => {
   const { id } = useParams<{ id: string }>()
   const { user: currentUser, isLoading: isAuthLoading } = useAuth()
   const isEditMode = Boolean(id)
-  const [loading, setLoading] = useState(isEditMode)
+  const [loading, setLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [initialState, setInitialState] = useState<RecipeFormInitialState>()
   const [recipeOverrides, setRecipeOverrides] = useState<Partial<Recipe>>({})
 
   useEffect(() => {
-    if (!isEditMode) {
-      setLoading(false)
-      setLoadError(null)
-      setInitialState(undefined)
-      setRecipeOverrides({})
-      return
-    }
-
-    if (!id || isAuthLoading) return
+    if (!isEditMode || !id || isAuthLoading) return
 
     let isMounted = true
 
@@ -1164,7 +1115,7 @@ export const SimpleCreateRecipe: React.FC = () => {
     }
   }, [currentUser?.uid, id, isAuthLoading, isEditMode, navigate])
 
-  if (isEditMode && loading) {
+  if (isEditMode && (loading || (!initialState && !loadError))) {
     return (
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center justify-center py-12">
@@ -1199,8 +1150,8 @@ export const SimpleCreateRecipe: React.FC = () => {
       key={id ?? 'create'}
       isEditMode={isEditMode}
       recipeId={id}
-      initialState={initialState}
-      recipeOverrides={recipeOverrides}
+      initialState={isEditMode ? initialState : undefined}
+      recipeOverrides={isEditMode ? recipeOverrides : {}}
     />
   )
 }

--- a/src/features/recipes/components/FieldAISuggestionChip.tsx
+++ b/src/features/recipes/components/FieldAISuggestionChip.tsx
@@ -5,6 +5,8 @@ import {
   AI_PRIMARY_ACTION_CLASS,
   AI_SECONDARY_ACTION_CLASS,
 } from './aiStyles'
+import { AIBadge } from './AIBadge'
+import { FIELD_LABELS } from '../constants/aiConstants'
 
 export interface FieldAISuggestionChipProps {
   field: string
@@ -13,15 +15,46 @@ export interface FieldAISuggestionChipProps {
   currentValue: string
   onApply: () => void
   onDismiss: () => void
+  error?: string | null
+  onRetry?: () => void
 }
 
 export const FieldAISuggestionChip: React.FC<FieldAISuggestionChipProps> = ({
+  field,
   suggestion,
   reason,
   currentValue,
   onApply,
   onDismiss,
+  error,
+  onRetry,
 }) => {
+  const fieldLabel = FIELD_LABELS[field] ?? field
+
+  if (error) {
+    return (
+      <div className={`mt-2 px-3 py-3 text-sm flex items-start gap-3 ${AI_MUTED_PANEL_CLASS}`} role="alert">
+        <AIBadge className="mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="font-medium text-rose-700 dark:text-rose-200">
+            Could not enhance {fieldLabel}.
+          </p>
+          <p className="mt-1 text-xs text-rose-600 dark:text-rose-300">{error}</p>
+        </div>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            aria-label={`Retry AI for ${fieldLabel}`}
+            className={AI_SECONDARY_ACTION_CLASS}
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className={`mt-2 px-3 py-3 text-sm flex items-start gap-3 animate-field-ai-chip-enter ${AI_MUTED_PANEL_CLASS}`}>
       <div className="flex-1 min-w-0">

--- a/src/features/recipes/components/RecipeFormLayout.tsx
+++ b/src/features/recipes/components/RecipeFormLayout.tsx
@@ -294,6 +294,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
     visibleSuggestions,
     status: suggestionStatus,
     error: suggestionError,
+    fieldErrors: fieldSuggestionErrors,
     fetchSuggestions,
     fetchFieldSuggestion,
     fieldStatus,
@@ -436,7 +437,6 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 onUndo={handleLocalUndo}
                 fieldLabels={FIELD_LABELS}
               />
-              {currentStep !== 5 && (
               <button
                 type="button"
                 onClick={handleEnhanceWithAI}
@@ -455,7 +455,6 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                   </>
                 )}
               </button>
-              )}
             </div>
         </div>
 
@@ -468,28 +467,25 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
         />
       </div>
 
-      {/* AI Suggestion Panel — shown on non-preview steps */}
-      {currentStep !== 5 && (
-        <AISuggestionPanel
-          suggestions={visibleSuggestions}
-          status={suggestionStatus}
-          error={suggestionError}
-          onApply={applySuggestion}
-          onDismiss={dismissSuggestion}
-          fieldSetters={fieldSetters}
-          currentValues={{
-            recipeName: title,
-            description,
-            prepTime,
-            cookTime,
-            servings,
-            tags: stringifySuggestionList(tags),
-            dietaryRestrictions: stringifySuggestionList(dietaryRestrictions),
-          }}
-          onRetry={handleRetrySuggestions}
-          currentStep={currentStep}
-        />
-      )}
+      <AISuggestionPanel
+        suggestions={visibleSuggestions}
+        status={suggestionStatus}
+        error={suggestionError}
+        onApply={applySuggestion}
+        onDismiss={dismissSuggestion}
+        fieldSetters={fieldSetters}
+        currentValues={{
+          recipeName: title,
+          description,
+          prepTime,
+          cookTime,
+          servings,
+          tags: stringifySuggestionList(tags),
+          dietaryRestrictions: stringifySuggestionList(dietaryRestrictions),
+        }}
+        onRetry={handleRetrySuggestions}
+        currentStep={currentStep}
+      />
 
       {/* Preview Step */}
       {currentStep === 5 ? (
@@ -560,6 +556,7 @@ export const RecipeFormLayout: React.FC<RecipeFormLayoutProps> = ({
                 onDismissNormalization={onDismissNormalization}
                 onEnhanceField={handleEnhanceField}
                 fieldStatus={fieldStatus}
+                fieldSuggestionErrors={fieldSuggestionErrors}
                 fieldSuggestions={fieldVisibleSuggestions}
                 onApplyFieldSuggestion={handleApplyFieldSuggestion}
                 onDismissFieldSuggestion={dismissSuggestion}

--- a/src/features/recipes/components/RecipeFormSteps.tsx
+++ b/src/features/recipes/components/RecipeFormSteps.tsx
@@ -74,6 +74,7 @@ interface RecipeFormStepsProps {
   // Per-field AI enhance
   onEnhanceField?: <K extends SuggestibleFieldKey>(field: K, currentValue: SuggestibleFieldValue<K>) => void
   fieldStatus?: Map<string, SuggestionStatus>
+  fieldSuggestionErrors?: Map<string, string>
   fieldSuggestions?: FieldSuggestion[]
   onApplyFieldSuggestion?: (suggestion: FieldSuggestion) => void
   onDismissFieldSuggestion?: (suggestion: FieldSuggestion) => void
@@ -132,6 +133,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
   onDismissNormalization,
   onEnhanceField,
   fieldStatus,
+  fieldSuggestionErrors,
   fieldSuggestions,
   onApplyFieldSuggestion,
   onDismissFieldSuggestion,
@@ -144,6 +146,37 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
 
   const getFieldSuggestion = (field: string): FieldSuggestion | undefined =>
     fieldSuggestions?.find(s => s.field === field && isFieldSuggestion(s))
+
+  const getFieldSuggestionError = (field: string): string | null =>
+    fieldSuggestionErrors?.get(field) ?? null
+
+  const renderFieldAIFeedback = <K extends SuggestibleFieldKey,>(
+    field: K,
+    currentValue: string,
+    fieldValue: SuggestibleFieldValue<K>
+  ) => {
+    const suggestion = getFieldSuggestion(field)
+    const error = getFieldSuggestionError(field)
+
+    if (!suggestion && !error) return null
+
+    return (
+      <FieldAISuggestionChip
+        field={field}
+        suggestion={suggestion?.suggestedValue ?? ''}
+        reason={suggestion?.reason}
+        currentValue={currentValue}
+        error={error}
+        onApply={() => {
+          if (suggestion) onApplyFieldSuggestion?.(suggestion)
+        }}
+        onDismiss={() => {
+          if (suggestion) onDismissFieldSuggestion?.(suggestion)
+        }}
+        onRetry={onEnhanceField ? () => onEnhanceField(field, fieldValue) : undefined}
+      />
+    )
+  }
 
   return (
     <div className="space-y-8">
@@ -193,19 +226,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 {fieldErrors.title}
               </p>
             )}
-            {onEnhanceField && (() => {
-              const s = getFieldSuggestion('recipeName')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="recipeName"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={title}
-                  onApply={() => onApplyFieldSuggestion?.(s)}
-                  onDismiss={() => onDismissFieldSuggestion?.(s)}
-                />
-              ) : null
-            })()}
+{onEnhanceField && renderFieldAIFeedback('recipeName', title, title)}
           </div>
 
           {/* Description */}
@@ -230,19 +251,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               placeholder="Brief description of your recipe..."
               className={UI_STYLES.input}
             />
-            {onEnhanceField && (() => {
-              const s = getFieldSuggestion('description')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="description"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={description}
-                  onApply={() => onApplyFieldSuggestion?.(s)}
-                  onDismiss={() => onDismissFieldSuggestion?.(s)}
-                />
-              ) : null
-            })()}
+{onEnhanceField && renderFieldAIFeedback('description', description, description)}
           </div>
 
           {/* Recipe Image Upload */}
@@ -499,19 +508,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               {fieldErrors.prepTime && (
                 <p className="mt-1 text-sm text-red-600" role="alert">{fieldErrors.prepTime}</p>
               )}
-              {onEnhanceField && (() => {
-                const s = getFieldSuggestion('prepTime')
-                return s ? (
-                  <FieldAISuggestionChip
-                    field="prepTime"
-                    suggestion={s.suggestedValue}
-                    reason={s.reason}
-                    currentValue={prepTime}
-                    onApply={() => onApplyFieldSuggestion?.(s)}
-                    onDismiss={() => onDismissFieldSuggestion?.(s)}
-                  />
-                ) : null
-              })()}
+{onEnhanceField && renderFieldAIFeedback('prepTime', prepTime, prepTime)}
             </div>
             <div>
               <div className="flex items-center gap-1.5 mb-2">
@@ -538,19 +535,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               {fieldErrors.cookTime && (
                 <p className="mt-1 text-sm text-red-600" role="alert">{fieldErrors.cookTime}</p>
               )}
-              {onEnhanceField && (() => {
-                const s = getFieldSuggestion('cookTime')
-                return s ? (
-                  <FieldAISuggestionChip
-                    field="cookTime"
-                    suggestion={s.suggestedValue}
-                    reason={s.reason}
-                    currentValue={cookTime}
-                    onApply={() => onApplyFieldSuggestion?.(s)}
-                    onDismiss={() => onDismissFieldSuggestion?.(s)}
-                  />
-                ) : null
-              })()}
+{onEnhanceField && renderFieldAIFeedback('cookTime', cookTime, cookTime)}
             </div>
             <div>
               <div className="flex items-center gap-1.5 mb-2">
@@ -577,19 +562,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
               {fieldErrors.servings && (
                 <p className="mt-1 text-sm text-red-600" role="alert">{fieldErrors.servings}</p>
               )}
-              {onEnhanceField && (() => {
-                const s = getFieldSuggestion('servings')
-                return s ? (
-                  <FieldAISuggestionChip
-                    field="servings"
-                    suggestion={s.suggestedValue}
-                    reason={s.reason}
-                    currentValue={servings}
-                    onApply={() => onApplyFieldSuggestion?.(s)}
-                    onDismiss={() => onDismissFieldSuggestion?.(s)}
-                  />
-                ) : null
-              })()}
+{onEnhanceField && renderFieldAIFeedback('servings', servings, servings)}
             </div>
           </div>
 
@@ -651,19 +624,7 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 ))}
               </div>
             )}
-            {onEnhanceField && (() => {
-              const s = getFieldSuggestion('tags')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="tags"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={stringifySuggestionList(tags)}
-                  onApply={() => onApplyFieldSuggestion?.(s)}
-                  onDismiss={() => onDismissFieldSuggestion?.(s)}
-                />
-              ) : null
-            })()}
+{onEnhanceField && renderFieldAIFeedback('tags', stringifySuggestionList(tags), tags)}
           </div>
           {/* Dietary Restrictions Section */}
           <div className="space-y-4">
@@ -723,19 +684,11 @@ export const RecipeFormSteps = React.memo<RecipeFormStepsProps>(({
                 ))}
               </div>
             )}
-            {onEnhanceField && (() => {
-              const s = getFieldSuggestion('dietaryRestrictions')
-              return s ? (
-                <FieldAISuggestionChip
-                  field="dietaryRestrictions"
-                  suggestion={s.suggestedValue}
-                  reason={s.reason}
-                  currentValue={stringifySuggestionList(dietaryRestrictions)}
-                  onApply={() => onApplyFieldSuggestion?.(s)}
-                  onDismiss={() => onDismissFieldSuggestion?.(s)}
-                />
-              ) : null
-            })()}
+{onEnhanceField && renderFieldAIFeedback(
+  'dietaryRestrictions',
+  stringifySuggestionList(dietaryRestrictions),
+  dietaryRestrictions
+)}
           </div>
         </div>
       )}

--- a/src/features/recipes/components/__tests__/FieldAISuggestionChip.test.tsx
+++ b/src/features/recipes/components/__tests__/FieldAISuggestionChip.test.tsx
@@ -140,4 +140,25 @@ describe('FieldAISuggestionChip', () => {
     expect(screen.getByRole('button', { name: /apply/i })).toBeVisible()
     expect(screen.getByRole('button', { name: /dismiss/i })).toBeVisible()
   })
+
+  it('renders an inline retry state when the AI request fails', () => {
+    const onRetry = vi.fn()
+    render(
+      <FieldAISuggestionChip
+        field="recipeName"
+        suggestion=""
+        currentValue=""
+        error="Network error"
+        onApply={vi.fn()}
+        onDismiss={vi.fn()}
+        onRetry={onRetry}
+      />
+    )
+
+    expect(screen.getByText(/Could not enhance Recipe Name\./i)).toBeInTheDocument()
+    expect(screen.getByText(/Network error/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Retry AI for Recipe Name/i }))
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
 })

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../../../utils/apiUtils', () => ({
 
 import { postWithAuth } from '../../../../utils/authApi'
 const mockPostWithAuth = vi.mocked(postWithAuth)
+type MockApiResponse = Awaited<ReturnType<typeof postWithAuth>>
 
 const mockIngredients = [{ quantity: '', unit: '', item: '' }]
 const mockSteps = [
@@ -130,13 +131,42 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     expect(screen.getByRole('button', { name: /AI assist/i })).toHaveClass('bg-gray-50', 'text-gray-700')
   })
 
-  it('does NOT render the "AI assist" button on step 5 (preview)', () => {
+  it('renders the "AI assist" button on step 5 (preview)', () => {
     renderWithRouter(makeProps({ currentStep: 5 }))
-    expect(screen.queryByRole('button', { name: /AI assist/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /AI assist/i })).toBeInTheDocument()
+  })
+
+  it('lets users apply tag suggestions directly from the preview step', async () => {
+    const setTags = vi.fn()
+    mockPostWithAuth.mockResolvedValueOnce({
+      data: {
+        suggestions: [
+          { field: 'tags', suggestedValue: 'quick, weeknight', reason: 'Helpful categorization' },
+        ],
+      },
+    } as MockApiResponse)
+
+    renderWithRouter(makeProps({
+      currentStep: 5,
+      title: 'Pasta',
+      ingredients: [{ quantity: '1', unit: 'lb', item: 'pasta' }],
+      instructions: ['Boil water'],
+      setTags,
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Apply AI suggestion for Tags/i })).toBeInTheDocument()
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply AI suggestion for Tags/i }))
+
+    expect(setTags).toHaveBeenCalledWith(['quick', 'weeknight'])
   })
 
   it('calls AI suggestions API when "AI assist" is clicked', async () => {
-    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as MockApiResponse)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
     fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
@@ -149,7 +179,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
   })
 
   it('includes dietary restrictions in the AI assist request payload', async () => {
-    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as any)
+    mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as MockApiResponse)
 
     renderWithRouter(makeProps({
       title: 'Pasta',
@@ -175,7 +205,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
           { field: 'description', suggestedValue: 'A tasty dish', reason: 'Empty' },
         ],
       },
-    } as any)
+    } as MockApiResponse)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
     // Panel is hidden before click
@@ -189,7 +219,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
   })
 
   it('disables the button while a fetch is in progress', async () => {
-    let resolvePost: (v: any) => void
+    let resolvePost: ((value: MockApiResponse) => void) | undefined
     mockPostWithAuth.mockImplementationOnce(() => new Promise(r => { resolvePost = r }))
 
     renderWithRouter(makeProps())
@@ -198,7 +228,7 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
 
     await waitFor(() => expect(btn).toBeDisabled())
 
-    resolvePost!({ data: { suggestions: [] } })
+    resolvePost!({ data: { suggestions: [] } } as MockApiResponse)
     await waitFor(() => expect(btn).not.toBeDisabled())
   })
 })
@@ -226,7 +256,7 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
           { field: 'description', suggestedValue: 'A tasty pasta dish', reason: 'Improve description' },
         ],
       },
-    } as any)
+    } as MockApiResponse)
 
     renderWithRouter(makeProps({ title: 'Pasta' }))
     fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
@@ -253,7 +283,7 @@ describe('RecipeFormLayout — AI undo affordance (issue #42)', () => {
           },
         ],
       },
-    } as any)
+    } as MockApiResponse)
 
     renderWithRouter(makeProps({
       currentStep: 4,
@@ -284,7 +314,7 @@ describe('RecipeFormLayout — AI nutrition completion', () => {
   })
 
   it('persists accepted nutrition estimates for saving', async () => {
-    mockPostWithAuth.mockResolvedValueOnce({ data: mockNutritionEstimate } as any)
+    mockPostWithAuth.mockResolvedValueOnce({ data: mockNutritionEstimate } as MockApiResponse)
     const onNutritionalInfoChange = vi.fn()
 
     renderWithRouter(makeProps({

--- a/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormLayout.test.tsx
@@ -165,6 +165,29 @@ describe('RecipeFormLayout — on-demand AI enhancement (issue #35)', () => {
     expect(setTags).toHaveBeenCalledWith(['quick', 'weeknight'])
   })
 
+  it('keeps bulk suggestion errors visible when a field-level enhancement fails', async () => {
+    mockPostWithAuth.mockRejectedValueOnce(new Error('Bulk request failed'))
+
+    renderWithRouter(makeProps({ currentStep: 1 }))
+    fireEvent.click(screen.getByRole('button', { name: /^AI assist$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Bulk request failed/i)).toBeInTheDocument()
+    })
+
+    mockPostWithAuth.mockRejectedValueOnce(new Error('Field request failed'))
+    const fieldButton = document.querySelector('button[data-field="recipeName"]')
+    expect(fieldButton).not.toBeNull()
+    fireEvent.click(fieldButton!)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not enhance Recipe Name\./i)).toBeInTheDocument()
+      expect(screen.getByText(/Field request failed/i)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(/Bulk request failed/i)).toBeInTheDocument()
+  })
+
   it('calls AI suggestions API when "AI assist" is clicked', async () => {
     mockPostWithAuth.mockResolvedValueOnce({ data: { suggestions: [] } } as MockApiResponse)
 

--- a/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
+++ b/src/features/recipes/components/__tests__/RecipeFormSteps.test.tsx
@@ -204,6 +204,24 @@ describe('RecipeFormSteps — per-field AI enhance (issue #40)', () => {
     expect(screen.getByText('Sounds great')).toBeInTheDocument()
   })
 
+  it('retries guided field enhancement with the current field value', () => {
+    const onEnhanceField = vi.fn()
+    render(
+      <RecipeFormSteps
+        {...makeProps({
+          currentStep: 4,
+          prepTime: '15',
+          onEnhanceField,
+          fieldSuggestionErrors: new Map([['prepTime', 'Network error']]),
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Retry AI for Prep Time \(min\)/i }))
+
+    expect(onEnhanceField).toHaveBeenCalledWith('prepTime', '15')
+  })
+
   it('calls onApplyFieldSuggestion when Apply clicked on chip', () => {
     const onApply = vi.fn()
     render(

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -150,7 +150,6 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       next.delete(field)
       return next
     })
-    setError(null)
 
     const request: FieldSuggestionRequest =
       field === 'tags' || field === 'dietaryRestrictions'
@@ -192,7 +191,6 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Failed to fetch AI suggestion'
-      setError(msg)
       setFieldStatus(prev => new Map(prev).set(field, 'error'))
       setFieldErrors(prev => new Map(prev).set(field, msg))
       console.warn('[AI Suggestions] fetchFieldSuggestion failed:', msg)

--- a/src/features/recipes/hooks/useAISuggestions.ts
+++ b/src/features/recipes/hooks/useAISuggestions.ts
@@ -60,6 +60,7 @@ interface UseAISuggestionsReturn {
   dismissedFields: Set<string>
   status: SuggestionStatus
   error: string | null
+  fieldErrors: Map<string, string>
   fetchSuggestions: (request: FieldSuggestionRequest) => Promise<void>
   fetchFieldSuggestion: <K extends SuggestibleFieldKey>(
     field: K,
@@ -90,6 +91,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
   const [status, setStatus] = useState<SuggestionStatus>('idle')
   const [error, setError] = useState<string | null>(null)
   const [fieldStatus, setFieldStatus] = useState<Map<string, SuggestionStatus>>(new Map())
+  const [fieldErrors, setFieldErrors] = useState<Map<string, string>>(new Map())
 
   const {
     auditLog,
@@ -105,6 +107,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     setSuggestions([])
     setDismissedFields(new Set())
     setFieldStatus(new Map())
+    setFieldErrors(new Map())
     setStatus('loading')
     setError(null)
     const startTime = Date.now()
@@ -142,6 +145,11 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     context?: Partial<FieldSuggestionRequest>
   ) => {
     setFieldStatus(prev => new Map(prev).set(field, 'loading'))
+    setFieldErrors(prev => {
+      const next = new Map(prev)
+      next.delete(field)
+      return next
+    })
     setError(null)
 
     const request: FieldSuggestionRequest =
@@ -173,6 +181,11 @@ export function useAISuggestions(): UseAISuggestionsReturn {
         return next
       })
       setFieldStatus(prev => new Map(prev).set(field, 'success'))
+      setFieldErrors(prev => {
+        const next = new Map(prev)
+        next.delete(field)
+        return next
+      })
 
       for (const s of fieldSuggestions) {
         recordSuggestion(s.field, s.suggestedValue)
@@ -181,6 +194,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
       const msg = err instanceof Error ? err.message : 'Failed to fetch AI suggestion'
       setError(msg)
       setFieldStatus(prev => new Map(prev).set(field, 'error'))
+      setFieldErrors(prev => new Map(prev).set(field, msg))
       console.warn('[AI Suggestions] fetchFieldSuggestion failed:', msg)
     }
   }, [recordSuggestion])
@@ -217,6 +231,7 @@ export function useAISuggestions(): UseAISuggestionsReturn {
     dismissedFields,
     status,
     error,
+    fieldErrors,
     fetchSuggestions,
     fetchFieldSuggestion,
     fieldStatus,


### PR DESCRIPTION
## Problem
AI-assisted recipe editing still had recovery gaps: preview hid bulk AI remediation, field-level AI failures were silent once a request failed, and quick entry needed stronger regression coverage for undo/apply parity on AI-driven tag changes.

## Changes
- keep AI assist and bulk suggestion application available from the guided preview step
- surface inline field-level AI errors with a retry action in guided create and quick entry
- track per-field AI request errors separately from bulk suggestion failures
- extend recipe creation tests to cover preview-step tag application, inline retry recovery, and quick-entry undo for AI-applied tags

This PR implements the interaction/recovery follow-up tracked in theandiman/recipe-management#46.